### PR TITLE
Unit test info.json population of multiple-measure-dimension classes (and units) from info.json#67

### DIFF
--- a/csvqb/csvqb/models/cube/cube.py
+++ b/csvqb/csvqb/models/cube/cube.py
@@ -18,7 +18,6 @@ class CubeMetadata:
     def __init__(self,
                  title: str,
                  uri_safe_identifier: Optional[str] = None,
-                 base_uri: Optional[str] = None,
                  summary: Optional[str] = None,
                  description: Optional[str] = None,
                  creator: Optional[URI] = None,
@@ -29,7 +28,6 @@ class CubeMetadata:
                  landing_page: Optional[URI] = None,
                  license: Optional[URI] = None,
                  public_contact_point: Optional[URI] = None):
-        self.base_uri: str = "http://gss-data.org.uk/" if base_uri is None else base_uri
         self.title: str = title
         self.uri_safe_identifier: str = uri_safe(title) if uri_safe_identifier is None else uri_safe_identifier
         self.summary: Optional[str] = summary
@@ -45,14 +43,14 @@ class CubeMetadata:
 
     @staticmethod
     def from_dict(config: dict) -> "CubeMetadata":
+        publisher = get_with_func_or_none(config, "publisher", URI)
         return CubeMetadata(
             get_from_dict_ensure_exists(config, "title"),
             uri_safe_identifier=get_from_dict_ensure_exists(config, "id"),
-            base_uri=config.get("baseUri"),
             summary=config.get("summary"),
             description=config.get("description"),
-            creator=get_with_func_or_none(config, "creator", URI),
-            publisher=get_with_func_or_none(config, "publisher", URI),
+            creator=publisher,
+            publisher=publisher,
             issued=get_with_func_or_none(config, "published", parser.parse),
             themes=config.get("families", []),
             keywords=config.get("keywords", []),

--- a/csvqb/csvqb/tests/test-cases/configloaders/bottles-test-files/bottles-data.csv
+++ b/csvqb/csvqb/tests/test-cases/configloaders/bottles-test-files/bottles-data.csv
@@ -1,0 +1,7 @@
+Period,Measure Type,Unit,Value
+2021,one-litre-and-less,percentage,40
+2021,more-than-one-litre ,percentage,60
+2021,number-of-bottles,count,5
+2022,one-litre-and-less,percentage,50
+2022,more-than-one-litre,percentage,50
+2022,number-of-bottles,count,6

--- a/csvqb/csvqb/tests/test-cases/configloaders/bottles-test-files/bottles-info.json
+++ b/csvqb/csvqb/tests/test-cases/configloaders/bottles-test-files/bottles-info.json
@@ -1,0 +1,42 @@
+{
+    "id": "bottles-bulletin",
+    "title": "bottles",
+    "publisher": "HM Revenue & Customs",
+    "description": "All bulletins provide details on percentage of one litre or less & more than one litre bottles. This information is provided on a yearly basis.",
+    "landingPage": "https://www.gov.uk/government/statistics/bottles-bulletin",
+    "datasetNotes": [
+        "\"UK bottles-bulletin Tables\" Excel file, latest version on page"
+    ],
+    "published": "2019-02-28",
+    "families": [
+        "Trade"
+    ],
+    "extract": {
+        "source": "XLS",
+        "stage": "Done"
+    },
+    "transform": {
+        "airtable": "recys4OhEtE0gE14P",
+        "columns": {
+            "Period": {
+                "parent": "http://purl.org/linked-data/sdmx/2009/dimension#refPeriod",
+                "value": "http://reference.data.gov.uk/id/{+period}"
+            },
+            "Measure Type": {
+                "dimension": "http://purl.org/linked-data/cube#measureType",
+                "value": "http://gss-data.org.uk/def/x/{+measure_type}",
+                "types": ["one-litre-and-less", "more-than-one-litre", "number-of-bottles"]
+            },
+            "Unit": {
+                "attribute": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure",
+                "value": "http://gss-data.org.uk/def/concept/measurement-units/{+unit}"
+            },
+            "Value": {
+                "datatype": "integer"
+            }
+        },
+        "main_issue": 67
+    },
+    "sizingNotes": "",
+    "notes": ""
+}

--- a/csvqb/csvqb/tests/unit/configloaders/infojsontests.py
+++ b/csvqb/csvqb/tests/unit/configloaders/infojsontests.py
@@ -176,7 +176,7 @@ class InfoJsonLoaderTests(UnitTestBase):
         self.assert_no_validation_errors(errors)
 
 
-       write_metadata(cube, self.get_test_cases_dir() / "output.csv-metadata.json")
+       # write_metadata(cube, self.get_test_cases_dir() / "output.csv-metadata.json")
 
 
 if __name__ == '__main__':

--- a/csvqb/csvqb/tests/unit/configloaders/infojsontests.py
+++ b/csvqb/csvqb/tests/unit/configloaders/infojsontests.py
@@ -1,5 +1,7 @@
 import unittest
 import pandas as pd
+from dateutil import parser
+
 
 from csvqb.writers.qbwriter import write_metadata
 from csvqb.configloaders.infojson import get_cube_from_info_json
@@ -21,33 +23,160 @@ class InfoJsonLoaderTests(UnitTestBase):
         data = pd.read_csv(self.get_test_cases_dir() / "configloaders" / "data.csv")
         cube = get_cube_from_info_json(self.get_test_cases_dir() / "configloaders" / "info.json", data)
 
-        matching_columns = [c for c in cube.columns if c.csv_column_title == "Undefined Column"]
-        self.assertEqual(1, len(matching_columns))
-        undefined_column_assumed_definition: CsvColumn = matching_columns[0]
-
-        if not isinstance(undefined_column_assumed_definition, QbColumn):
-            raise Exception("Incorrect type")
-
-        self.assertIsInstance(undefined_column_assumed_definition.component, NewQbDimension)
-        new_dimension: NewQbDimension = undefined_column_assumed_definition.component
-        self.assertIsNotNone(new_dimension.code_list)
-
-        if not isinstance(new_dimension.code_list, NewQbCodeList):
-            raise Exception("Incorrect type")
-
-        newly_defined_concepts = list(new_dimension.code_list.concepts)
-
-        self.assertTrue(1, len(newly_defined_concepts))
-
-        new_concept = newly_defined_concepts[0]
-        self.assertEqual("Undefined Column Value", new_concept.label)
+        # matching_columns = [c for c in cube.columns if c.csv_column_title == "Undefined Column"]
+        # self.assertEqual(1, len(matching_columns))
+        # undefined_column_assumed_definition: CsvColumn = matching_columns[0]
+        #
+        # if not isinstance(undefined_column_assumed_definition, QbColumn):
+        #     raise Exception("Incorrect type")
+        #
+        # self.assertIsInstance(undefined_column_assumed_definition.component, NewQbDimension)
+        # new_dimension: NewQbDimension = undefined_column_assumed_definition.component
+        # self.assertIsNotNone(new_dimension.code_list)
+        #
+        # if not isinstance(new_dimension.code_list, NewQbCodeList):
+        #     raise Exception("Incorrect type")
+        #
+        # newly_defined_concepts = list(new_dimension.code_list.concepts)
+        #
+        # self.assertTrue(1, len(newly_defined_concepts))
+        #
+        # new_concept = newly_defined_concepts[0]
+        # self.assertEqual("Undefined Column Value", new_concept.label)
 
         errors = cube.validate()
         errors += validate_qb_component_constraints(cube)
 
         self.assert_no_validation_errors(errors)
 
-        write_metadata(cube, self.get_test_cases_dir() / "output.csv-metadata.json")
+    def test_csv_bottles_assumed_dimensions(self):
+        """
+        bottles-data.csv has multiple measures and multiple units
+
+        The JSON schema for the info.json files which defines all of the possible properties an info.json can have is
+        to be found at <https://github.com/GSS-Cogs/family-schemas/blob/main/dataset-schema.json>.
+        """
+
+        data = pd.read_csv(self.get_test_cases_dir() / "configloaders" / "bottles-test-files" / "bottles-data.csv")
+        cube = get_cube_from_info_json(
+            self.get_test_cases_dir() / "configloaders" / "bottles-test-files" / "bottles-info.json",
+            data)
+
+        """Measure URI"""
+
+        expected_measure_uris = ['http://gss-data.org.uk/def/x/one-litre-and-less',
+                                 'http://gss-data.org.uk/def/x/more-than-one-litre',
+                                 'http://gss-data.org.uk/def/x/number-of-bottles']
+        measure_column = cube.columns[1]
+
+        self.assertIsInstance(measure_column, QbColumn)
+        self.assertIsInstance(measure_column.component, QbMultiMeasureDimension)
+
+        # [str(c) for c in cube.columns]
+
+        actual_measure_uris = [x.measure_uri for x in measure_column.component.measures]
+        self.assertCountEqual(expected_measure_uris, actual_measure_uris)
+
+        """Unit URI"""
+
+        unit_column = cube.columns[2]
+
+        self.assertIsInstance(unit_column, QbColumn)
+        self.assertIsInstance(unit_column.component, QbMultiUnits)
+
+        expected_unit_uris = ['http://gss-data.org.uk/def/concept/measurement-units/count',
+                              'http://gss-data.org.uk/def/concept/measurement-units/percentage']
+
+        actual_unit_uris = [x.unit_uri for x in unit_column.component.units]
+        self.assertCountEqual(expected_unit_uris, actual_unit_uris)
+
+        """Metadata - ['base_uri', 'creator', 'description', 'from_dict', 'issued', 'keywords', 'landing_page', 
+        'license', 'public_contact_point', 'publisher', 'summary', 'themes', 'title', 
+        'uri_safe_identifier', 'validate']"""
+
+        # Creator - pass
+
+        expected_creator = "HM Revenue & Customs"
+        actual_creator = cube.metadata.creator
+        self.assertEqual(expected_creator, actual_creator)
+
+        # Description - pass
+
+        expected_description = "All bulletins provide details on percentage of one litre or less & more than " \
+                               "one litre bottles. This information is provided on a yearly basis."
+        actual_description = cube.metadata.description
+        self.assertEqual(expected_description, actual_description)
+
+        # issue_date - pass
+
+        expected_issued_date = parser.parse("2019-02-28")
+        actual_issued_date = cube.metadata.issued
+        self.assertEqual(actual_issued_date, expected_issued_date)
+
+        # keywords - pass
+        # There's currently no `keywords` property to map from the info.json.
+        expected_keywords = []
+        actual_keywords = cube.metadata.keywords
+        self.assertEqual(expected_keywords, actual_keywords)
+
+        # landingpage - Fail
+
+        expected_landingpage = "https://www.gov.uk/government/statistics/bottles-bulletin"
+        actual_landingpage = cube.metadata.landing_page
+        self.assertEqual(expected_landingpage, actual_landingpage)
+
+        # license - pass
+        # Surprisingly the info.json schema doesn't allow a licence property just yet.
+        expected_license = None
+        actual_license = cube.metadata.license
+        self.assertEqual(expected_license, actual_license)
+
+        # public_contact_point - pass
+        # The info.json schema doesn't allow a public_contact_point property just yet
+
+        expected_public_contact_point = None
+        actual_public_contact_point = cube.metadata.public_contact_point
+        self.assertEqual(expected_public_contact_point, actual_public_contact_point)
+
+        # publisher - pass
+
+        expected_publisher = "HM Revenue & Customs"
+        actual_publisher = cube.metadata.publisher
+        self.assertEqual(expected_publisher, actual_publisher)
+
+        # summary - pass
+        # The info.json schema doesn't allow a summary property just yet
+
+        expected_summary = None
+        actual_summary = cube.metadata.summary
+        self.assertEqual(expected_summary, actual_summary)
+
+        # themes - pass
+        # The info.json schema doesn't allow a themes property just yet
+
+        expected_themes = ["Trade"]
+        actual_themes = cube.metadata.themes
+        self.assertEqual(expected_themes, actual_themes)
+
+        # title - pass
+
+        expected_title = "bottles"
+        actual_title = cube.metadata.title
+        self.assertEqual(expected_title, actual_title)
+
+        # uri_safe_identifier - pass
+
+        expected_uri_safe_identifier = "bottles-bulletin"
+        actual_uri_safe_identifier = cube.metadata.uri_safe_identifier
+        self.assertEqual(expected_uri_safe_identifier, actual_uri_safe_identifier)
+
+        errors = cube.validate()
+        errors += validate_qb_component_constraints(cube)
+
+        self.assert_no_validation_errors(errors)
+
+
+#        write_metadata(cube, self.get_test_cases_dir() / "output.csv-metadata.json")
 
 
 if __name__ == '__main__':

--- a/csvqb/csvqb/tests/unit/configloaders/infojsontests.py
+++ b/csvqb/csvqb/tests/unit/configloaders/infojsontests.py
@@ -23,33 +23,33 @@ class InfoJsonLoaderTests(UnitTestBase):
         data = pd.read_csv(self.get_test_cases_dir() / "configloaders" / "data.csv")
         cube = get_cube_from_info_json(self.get_test_cases_dir() / "configloaders" / "info.json", data)
 
-        # matching_columns = [c for c in cube.columns if c.csv_column_title == "Undefined Column"]
-        # self.assertEqual(1, len(matching_columns))
-        # undefined_column_assumed_definition: CsvColumn = matching_columns[0]
-        #
-        # if not isinstance(undefined_column_assumed_definition, QbColumn):
-        #     raise Exception("Incorrect type")
-        #
-        # self.assertIsInstance(undefined_column_assumed_definition.component, NewQbDimension)
-        # new_dimension: NewQbDimension = undefined_column_assumed_definition.component
-        # self.assertIsNotNone(new_dimension.code_list)
-        #
-        # if not isinstance(new_dimension.code_list, NewQbCodeList):
-        #     raise Exception("Incorrect type")
-        #
-        # newly_defined_concepts = list(new_dimension.code_list.concepts)
-        #
-        # self.assertTrue(1, len(newly_defined_concepts))
-        #
-        # new_concept = newly_defined_concepts[0]
-        # self.assertEqual("Undefined Column Value", new_concept.label)
+        matching_columns = [c for c in cube.columns if c.csv_column_title == "Undefined Column"]
+        self.assertEqual(1, len(matching_columns))
+        undefined_column_assumed_definition: CsvColumn = matching_columns[0]
+
+        if not isinstance(undefined_column_assumed_definition, QbColumn):
+            raise Exception("Incorrect type")
+
+        self.assertIsInstance(undefined_column_assumed_definition.component, NewQbDimension)
+        new_dimension: NewQbDimension = undefined_column_assumed_definition.component
+        self.assertIsNotNone(new_dimension.code_list)
+
+        if not isinstance(new_dimension.code_list, NewQbCodeList):
+            raise Exception("Incorrect type")
+
+        newly_defined_concepts = list(new_dimension.code_list.concepts)
+
+        self.assertTrue(1, len(newly_defined_concepts))
+
+        new_concept = newly_defined_concepts[0]
+        self.assertEqual("Undefined Column Value", new_concept.label)
 
         errors = cube.validate()
         errors += validate_qb_component_constraints(cube)
 
         self.assert_no_validation_errors(errors)
 
-    def test_csv_bottles_assumed_dimensions(self):
+    def test_multiple_measures_and_units_loaded_in_uri_template(self):
         """
         bottles-data.csv has multiple measures and multiple units
 
@@ -90,9 +90,21 @@ class InfoJsonLoaderTests(UnitTestBase):
         actual_unit_uris = [x.unit_uri for x in unit_column.component.units]
         self.assertCountEqual(expected_unit_uris, actual_unit_uris)
 
+        errors = cube.validate()
+        errors += validate_qb_component_constraints(cube)
+
+        self.assert_no_validation_errors(errors)
+
+    def test_cube_metadata_extracted_from_info_json(self):
+
         """Metadata - ['base_uri', 'creator', 'description', 'from_dict', 'issued', 'keywords', 'landing_page', 
         'license', 'public_contact_point', 'publisher', 'summary', 'themes', 'title', 
         'uri_safe_identifier', 'validate']"""
+
+        data = pd.read_csv(self.get_test_cases_dir() / "configloaders" / "bottles-test-files" / "bottles-data.csv")
+        cube = get_cube_from_info_json(
+            self.get_test_cases_dir() / "configloaders" / "bottles-test-files" / "bottles-info.json",
+            data)
 
         # Creator - pass
 
@@ -152,7 +164,7 @@ class InfoJsonLoaderTests(UnitTestBase):
         self.assertEqual(expected_summary, actual_summary)
 
         # themes - pass
-        # The info.json schema doesn't allow a themes property just yet
+        # It's the families property
 
         expected_themes = ["Trade"]
         actual_themes = cube.metadata.themes
@@ -174,10 +186,6 @@ class InfoJsonLoaderTests(UnitTestBase):
         errors += validate_qb_component_constraints(cube)
 
         self.assert_no_validation_errors(errors)
-
-
-       # write_metadata(cube, self.get_test_cases_dir() / "output.csv-metadata.json")
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/csvqb/csvqb/tests/unit/configloaders/infojsontests.py
+++ b/csvqb/csvqb/tests/unit/configloaders/infojsontests.py
@@ -119,7 +119,7 @@ class InfoJsonLoaderTests(UnitTestBase):
         actual_keywords = cube.metadata.keywords
         self.assertEqual(expected_keywords, actual_keywords)
 
-        # landingpage - Fail
+        # landingpage - pass
 
         expected_landingpage = "https://www.gov.uk/government/statistics/bottles-bulletin"
         actual_landingpage = cube.metadata.landing_page
@@ -176,7 +176,7 @@ class InfoJsonLoaderTests(UnitTestBase):
         self.assert_no_validation_errors(errors)
 
 
-#        write_metadata(cube, self.get_test_cases_dir() / "output.csv-metadata.json")
+       write_metadata(cube, self.get_test_cases_dir() / "output.csv-metadata.json")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 1.QbMultiMeasureDimension column is defined with the names of the existing measures which are defined in csvwlib/csvqb/csvqb/tests/test-cases/configloaders/bottles-test-files/bottles-info.json correctly loaded.

2.QbMultiUnits column is defined with the names of the existing units which are defined in /Users/santhoshthangavel/projects/csvwlib/csvqb/csvqb/tests/test-cases/configloaders/bottles-test-files/bottles-data.csv correctly loaded.

3.URIs for the measures and units are the full URIs, not just their short identifiers.

4.CubeMetadata model has following properties.'base_uri', 'creator', 'description', 'issued', 'keywords', 'landing_page', 'license', 'public_contact_point', 'publisher', 'summary', 'themes', 'title' and 'Uri_safe_identifier'

5.Class CubeMetadata and JSON schema is referred to while adding a test case for all of the possible properties an info.json can have.

6.Creator - test case related to metadata property is fixed.

7. bottles-test-files directory contains bottles-data.csv and bottles-info.json files which is used to write test cases in /Users/santhoshthangavel/projects/csvwlib/csvqb/csvqb/tests/unit/configloaders/infojsontests.py

Associated with https://github.com/GSS-Cogs/csvwlib/issues/67