### PR TITLE
Issue #64 - Implementing tests for the QbWriter class.

### DIFF
--- a/csvqb/csvqb/tests/unit/writers/qbwritertests.py
+++ b/csvqb/csvqb/tests/unit/writers/qbwritertests.py
@@ -1,6 +1,6 @@
+import unittest
 from copy import deepcopy
 from typing import List
-
 import pandas as pd
 from sharedmodels.rdf import qb
 
@@ -302,3 +302,7 @@ class QbWriterTests(UnitTestBase):
         self.assertTrue(virt_unit["virtual"])
         self.assertEqual("http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure", virt_unit["propertyUrl"])
         self.assertEqual("#unit/some-unit", virt_unit["valueUrl"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/csvqb/csvqb/tests/unit/writers/qbwritertests.py
+++ b/csvqb/csvqb/tests/unit/writers/qbwritertests.py
@@ -7,7 +7,7 @@ from sharedmodels.rdf import qb
 from csvqb.models.cube import *
 from csvqb.tests.unit.unittestbase import UnitTestBase
 from csvqb.utils.iterables import first
-from csvqb.writers.qbwriter import _generate_qb_dataset_dsd_definitions
+from csvqb.writers import qbwriter
 
 
 def _get_standard_cube_for_columns(columns: List[CsvColumn]) -> Cube:
@@ -43,7 +43,7 @@ class QbWriterTests(UnitTestBase):
                 ExistingQbUnit("http://example.org/units/some-existing-unit")))
         ])
 
-        dataset = _generate_qb_dataset_dsd_definitions(cube)
+        dataset = qbwriter._generate_qb_dataset_dsd_definitions(cube)
 
         self.assertIsNotNone(dataset)
 
@@ -56,3 +56,169 @@ class QbWriterTests(UnitTestBase):
         _assert_component_defined(dataset, "marker")
         _assert_component_defined(dataset, "some-existing-unit")
         _assert_component_defined(dataset, "some-existing-measure")
+
+    def test_generating_concept_uri_template_from_global_concept_scheme_uri(self):
+        """
+            Given a globally defined skos:ConceptScheme's URI, generate the URI template for a column which maps the
+            column's value to a concept defined inside the concept scheme.
+        """
+        column = SuppressedCsvColumn("Some Column")
+        code_list = ExistingQbCodeList("http://base-uri/concept-scheme/this-concept-scheme-name")
+
+        actual_concept_template_uri = qbwriter._get_default_value_uri_for_code_list_concepts(column, code_list)
+        self.assertEqual("http://base-uri/concept-scheme/this-concept-scheme-name/{+some_column}",
+                         actual_concept_template_uri)
+
+    def test_generating_concept_uri_template_from_local_concept_scheme_uri(self):
+        """
+            Given a dataset-local skos:ConceptScheme's URI, generate the URI template for a column which maps the
+            column's value to a concept defined inside the concept scheme.
+        """
+        column = SuppressedCsvColumn("Some Column")
+        code_list = ExistingQbCodeList("http://base-uri/dataset-name#scheme/that-concept-scheme-name")
+
+        actual_concept_template_uri = qbwriter._get_default_value_uri_for_code_list_concepts(column, code_list)
+        self.assertEqual("http://base-uri/dataset-name#concept/that-concept-scheme-name/{+some_column}",
+                         actual_concept_template_uri)
+
+    def test_generating_concept_uri_template_from_unexpected_concept_scheme_uri(self):
+        """
+            Given a skos:ConceptScheme's URI *that does not follow the global or dataset-local conventions* used in our
+            tooling, return the column's value as our best guess at the concept's URI.
+        """
+        column = SuppressedCsvColumn("Some Column")
+        code_list = ExistingQbCodeList("http://base-uri/dataset-name#codes/that-concept-scheme-name")
+
+        actual_concept_template_uri = qbwriter._get_default_value_uri_for_code_list_concepts(column, code_list)
+        self.assertEqual("{+some_column}", actual_concept_template_uri)
+
+    def test_default_property_value_uris_existing_dimension_column(self):
+        """
+            When an existing dimension is used, we can provide the `propertyUrl`, but we cannot guess the `valueUrl`.
+        """
+        column = QbColumn("Some Column", ExistingQbDimension("http://base-uri/dimensions/existing-dimension"))
+        default_property_uri, default_value_uri = qbwriter._get_default_property_value_uris_for_column(column)
+        self.assertEqual("http://base-uri/dimensions/existing-dimension", default_property_uri)
+        self.assertEqual("{+some_column}", default_value_uri)
+
+    def test_default_property_value_uris_new_dimension_column_without_code_list(self):
+        """
+            When a new dimension is defined without a code list, we can provide the `propertyUrl`,
+            but we cannot guess the `valueUrl`.
+        """
+        column = QbColumn("Some Column", NewQbDimension("Some New Dimension"))
+        default_property_uri, default_value_uri = qbwriter._get_default_property_value_uris_for_column(column)
+        self.assertEqual("#dimension/some-new-dimension", default_property_uri)
+        self.assertEqual("{+some_column}", default_value_uri)
+
+    def test_default_property_value_uris_new_dimension_column_with_code_list(self):
+        """
+            When an new dimension is defined with a code list, we can provide the `propertyUrl` and the `valueUrl`.
+        """
+        column = QbColumn("Some Column",
+                          NewQbDimension("Some New Dimension",
+                                         code_list=ExistingQbCodeList("http://base-uri/concept-scheme/this-scheme")))
+        default_property_uri, default_value_uri = qbwriter._get_default_property_value_uris_for_column(column)
+        self.assertEqual("#dimension/some-new-dimension", default_property_uri)
+        self.assertEqual("http://base-uri/concept-scheme/this-scheme/{+some_column}", default_value_uri)
+
+    def test_default_property_value_uris_existing_attribute_column(self):
+        """
+            When an existing attribute is used, we can provide the `propertyUrl`, but we cannot guess the `valueUrl`.
+        """
+        column = QbColumn("Some Column", ExistingQbAttribute("http://base-uri/attributes/existing-attribute"))
+        default_property_uri, default_value_uri = qbwriter._get_default_property_value_uris_for_column(column)
+        self.assertEqual("http://base-uri/attributes/existing-attribute", default_property_uri)
+        self.assertEqual("{+some_column}", default_value_uri)
+
+    def test_default_property_value_uris_existing_attribute_column(self):
+        """
+            When a new attribute is defined, we can provide the `propertyUrl`, but we cannot guess the `valueUrl`.
+        """
+        column = QbColumn("Some Column", NewQbAttribute("This New Attribute"))
+        default_property_uri, default_value_uri = qbwriter._get_default_property_value_uris_for_column(column)
+        self.assertEqual("#attribute/this-new-attribute", default_property_uri)
+        self.assertEqual("{+some_column}", default_value_uri)
+
+    def test_default_property_value_uris_multi_units_all_new(self):
+        """
+            When a QbMultiUnits component is defined using only new/locally defined units, we can provide the
+            `propertyUrl` and the `valueUrl`.
+        """
+        column = QbColumn("Some Column", QbMultiUnits([NewQbUnit("Some New Unit")]))
+        default_property_uri, default_value_uri = qbwriter._get_default_property_value_uris_for_column(column)
+        self.assertEqual("http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure", default_property_uri)
+        self.assertEqual("#unit/{+some_column}", default_value_uri)
+
+    def test_default_property_value_uris_multi_units_all_existing(self):
+        """
+            When a QbMultiUnits component is defined using just existing units, we can provide the `propertyUrl` and
+            `valueUrl`.
+        """
+        column = QbColumn("Some Column", QbMultiUnits([ExistingQbUnit("http://base-uri/units/existing-unit")]))
+        default_property_uri, default_value_uri = qbwriter._get_default_property_value_uris_for_column(column)
+        self.assertEqual("http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure", default_property_uri)
+        self.assertEqual("{+some_column}", default_value_uri)
+
+    def test_default_property_value_uris_multi_units_local_and_existing(self):
+        """
+            When a QbMultiUnits component is defined using a mixture of existing units and new units, we can't provide
+            an appropriate and consistent `valueUrl`.
+
+            An exception is raised when this is attempted.
+        """
+        column = QbColumn("Some Column", QbMultiUnits([NewQbUnit("Some New Unit"),
+                                                       ExistingQbUnit("http://base-uri/units/existing-unit")]))
+        self.assertRaises(Exception, lambda _: qbwriter._get_default_property_value_uris_for_column(column))
+
+    def test_default_property_value_uris_multi_measure_all_new(self):
+        """
+            When a QbMultiMeasureDimension component is defined using only new/locally defined measures,
+            we can provide the `propertyUrl` and the `valueUrl`.
+        """
+        column = QbColumn("Some Column", QbMultiMeasureDimension([NewQbMeasure("Some New Measure")]))
+        default_property_uri, default_value_uri = qbwriter._get_default_property_value_uris_for_column(column)
+        self.assertEqual("http://purl.org/linked-data/cube#measureType", default_property_uri)
+        self.assertEqual("#measure/{+some_column}", default_value_uri)
+
+    def test_default_property_value_uris_multi_measure_all_existing(self):
+        """
+            When a QbMultiUnits component is defined using just existing units, we can provide the `propertyUrl` and
+            `valueUrl`.
+        """
+        column = QbColumn("Some Column",
+                          QbMultiMeasureDimension([ExistingQbMeasure("http://base-uri/measures/existing-measure")]))
+        default_property_uri, default_value_uri = qbwriter._get_default_property_value_uris_for_column(column)
+        self.assertEqual("http://purl.org/linked-data/cube#measureType", default_property_uri)
+        self.assertEqual("{+some_column}", default_value_uri)
+
+    def test_default_property_value_uris_multi_measure_local_and_existing(self):
+        """
+            When a QbMultiUnits component is defined using a mixture of existing units and new units, we can't provide
+            an appropriate and consistent `valueUrl`.
+
+            An exception is raised when this is attempted.
+        """
+        column = QbColumn("Some Column",
+                          QbMultiMeasureDimension([NewQbMeasure("Some New Measure"),
+                                                   ExistingQbMeasure("http://base-uri/measures/existing-measure")]))
+        self.assertRaises(Exception, lambda _: qbwriter._get_default_property_value_uris_for_column(column))
+
+    def test_default_property_value_uris_single_measure_obs_val(self):
+        """
+            There should be no `propertyUrl` or `valueUrl` for a `QbSingleMeasureObservationValue`.
+        """
+        column = QbColumn("Some Column", QbSingleMeasureObservationValue(NewQbUnit("New Unit"),
+                                                                         NewQbMeasure("New Qb Measure")))
+        default_property_uri, default_value_uri = qbwriter._get_default_property_value_uris_for_column(column)
+        self.assertIsNone(default_property_uri)
+        self.assertIsNone(default_value_uri)
+
+    def test_default_property_value_uris_multi_measure_obs_val(self):
+        """
+            There should be no `propertyUrl` or `valueUrl` for a `QbMultiMeasureObservationValue`.
+        """
+        column = QbColumn("Some Column", QbMultiMeasureObservationValue())
+        default_property_uri, default_value_uri = qbwriter._get_default_property_value_uris_for_column(column)
+        self.assertIsNone(default_property_uri)
+        self.assertIsNone(default_value_uri)

--- a/csvqb/csvqb/tests/unit/writers/qbwritertests.py
+++ b/csvqb/csvqb/tests/unit/writers/qbwritertests.py
@@ -268,3 +268,37 @@ class QbWriterTests(UnitTestBase):
         self.assertEqual("some_column", csv_col["name"])
         self.assertFalse("propertyUrl" in csv_col)
         self.assertFalse("valueUrl" in csv_col)
+
+    def test_virtual_columns_generated_for_single_obs_val(self):
+        """
+            Ensure that the virtual columns generated for a `QbSingleMeasureObservationValue`'s unit and measure are
+            correct.
+        """
+        obs_val = QbSingleMeasureObservationValue(NewQbMeasure("Some Measure"), NewQbUnit("Some Unit"))
+        virtual_columns = qbwriter._generate_virtual_columns_for_obs_val(obs_val)
+
+        virt_unit = first(virtual_columns, lambda x: x["name"] == "virt_unit")
+        self.assertIsNotNone(virt_unit)
+        self.assertTrue(virt_unit["virtual"])
+        self.assertEqual("http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure", virt_unit["propertyUrl"])
+        self.assertEqual("#unit/some-unit", virt_unit["valueUrl"])
+
+        virt_measure = first(virtual_columns, lambda x: x["name"] == "virt_measure")
+        self.assertIsNotNone(virt_measure)
+        self.assertTrue(virt_measure["virtual"])
+        self.assertEqual("http://purl.org/linked-data/cube#measureType", virt_measure["propertyUrl"])
+        self.assertEqual("#measure/some-measure", virt_measure["valueUrl"])
+
+    def test_virtual_columns_generated_for_multi_meas_obs_val(self):
+        """
+            Ensure that the virtual column generated for a `QbMultiMeasureObservationValue`'s unit and measure are
+            correct.
+        """
+        obs_val = QbMultiMeasureObservationValue(unit=NewQbUnit("Some Unit"))
+        virtual_columns = qbwriter._generate_virtual_columns_for_obs_val(obs_val)
+
+        virt_unit = first(virtual_columns, lambda x: x["name"] == "virt_unit")
+        self.assertIsNotNone(virt_unit)
+        self.assertTrue(virt_unit["virtual"])
+        self.assertEqual("http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure", virt_unit["propertyUrl"])
+        self.assertEqual("#unit/some-unit", virt_unit["valueUrl"])


### PR DESCRIPTION
The PR adds tests ensuring the following:
- URIs are correctly inferred for dimensions/attributes/measures/units when outputting CSV-W.
- URIs for Concepts are correctly inferred from conventionaly defined ConceptScheme URIs allowing us to infer the `propertyUrl` for a dimension's column.
- `QbColumn.output_uri_template` correctly overrides the default value we infer for the CSV-W column's `propertyUrl`.
- Defining a `SuppressedCsvColumn` sets `"suppressOutput": true` on the corresponding CSV-W column.
- Virtual columns for unit and measure are correctly generated where the dataset has a single measure and/or unit.


https://github.com/GSS-Cogs/csvwlib/issues/64