### PR TITLE
Issue#83 - Add a validation error when user uses an ExistingDimension without providing a column.output_uri_template.

### DIFF
--- a/csvqb/csvqb/tests/unit/cube/qb/errorvalidation.py
+++ b/csvqb/csvqb/tests/unit/cube/qb/errorvalidation.py
@@ -1,10 +1,11 @@
 import unittest
+
 import pandas as pd
 
 from csvqb.models.cube import *
 from csvqb.models.rdf import URI
-from csvqb.utils.qb.cube import validate_qb_component_constraints
 from csvqb.tests.unit.unittestbase import UnitTestBase
+from csvqb.utils.qb.cube import validate_qb_component_constraints
 
 
 class InternalApiLoaderTests(UnitTestBase):
@@ -83,6 +84,10 @@ class InternalApiLoaderTests(UnitTestBase):
         errors += validate_qb_component_constraints(cube)
 
         self.assertEqual(1, len(errors))
+        validation_errors = errors[0]
+        self.assertTrue(
+            "'Existing Dimension' - an ExistingQbDimension must have an output_uri_template defined."
+                        in validation_errors.message)
 
 
 if __name__ == '__main__':

--- a/csvqb/csvqb/utils/qb/cube.py
+++ b/csvqb/csvqb/utils/qb/cube.py
@@ -32,7 +32,7 @@ def _validate_dimensions(cube: Cube) -> List[ValidationError]:
     dimension_columns = get_columns_of_dsd_type(cube, QbDimension)
 
     for c in cube.columns:
-        if isinstance(c.component, ExistingQbDimension):
+        if isinstance(c, QbColumn) and isinstance(c.component, ExistingQbDimension):
             if c.output_uri_template is None:
                 errors.append(
                     ValidationError(f"'{c.csv_column_title}' - an ExistingQbDimension must have an output_uri_template "

--- a/csvqb/csvqb/utils/qb/cube.py
+++ b/csvqb/csvqb/utils/qb/cube.py
@@ -4,7 +4,7 @@ from typing import List, TypeVar, Type
 from csvqb.models.validationerror import ValidationError
 from csvqb.models.cube.cube import Cube
 from csvqb.models.cube.csvqb.columns import QbColumn
-from csvqb.models.cube.csvqb.components.dimension import QbDimension
+from csvqb.models.cube.csvqb.components.dimension import QbDimension, ExistingQbDimension
 from csvqb.models.cube.csvqb.components.measure import QbMultiMeasureDimension
 from csvqb.models.cube.csvqb.components.unit import QbMultiUnits
 from csvqb.models.cube.csvqb.components.observedvalue import QbObservationValue, QbMultiMeasureObservationValue, \
@@ -21,6 +21,7 @@ def get_columns_of_dsd_type(cube: Cube, t: Type[QbColumnarDsdType]) -> List[QbCo
 
 def validate_qb_component_constraints(cube: Cube) -> List[ValidationError]:
     # assert validation specific to a cube-qb
+
     errors = _validate_dimensions(cube)
     errors += _validate_observation_value_constraints(cube)
     return errors
@@ -29,6 +30,14 @@ def validate_qb_component_constraints(cube: Cube) -> List[ValidationError]:
 def _validate_dimensions(cube: Cube) -> List[ValidationError]:
     errors: List[ValidationError] = []
     dimension_columns = get_columns_of_dsd_type(cube, QbDimension)
+
+    for c in cube.columns:
+        if isinstance(c.component, ExistingQbDimension):
+            if c.output_uri_template is None:
+                errors.append(
+                    ValidationError(f"'{c.csv_column_title}' - an ExistingQbDimension must have an output_uri_template "
+                                    "defined."))
+
     if len(dimension_columns) == 0:
         errors.append(ValidationError("At least one dimension must be defined."))
     return errors


### PR DESCRIPTION
1.QB with an existing dimension and without an output_uri_template is defined.
2.A Validation error is generated when user provides an existing dimension but not a column.output_uri_template.
3.Test case written to capture the number of errors.

#83