### PR TITLE
Issue #23 - Adding DCAT metadata to the qb:DataSet output

### DIFF
--- a/csvqb/csvqb/models/cube/csvqb/catalog.py
+++ b/csvqb/csvqb/models/cube/csvqb/catalog.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Optional, List
+from sharedmodels.rdf import dcat
 
 from csvqb.models.validationerror import ValidationError
 from csvqb.utils.uri import uri_safe
@@ -37,3 +38,16 @@ class CatalogMetadata(CatalogMetadataBase):
 
     def validate(self) -> List[ValidationError]:
         return CatalogMetadataBase.validate(self) + []  # TODO: augment this
+
+    def configure_dcat_dataset(self, dataset: dcat.Dataset) -> None:
+        dt_now = datetime.now()
+        dataset.label = dataset.title = self.title
+        dataset.issued = self.issued or dt_now
+        dataset.modified = dt_now
+        dataset.comment = self.summary
+        dataset.description = self.description
+        dataset.license = self.license_uri
+        dataset.publisher = self.publisher_uri
+        dataset.landing_page = self.landing_page_uri
+        dataset.themes = set(self.theme_uris)
+        dataset.keywords = set(self.keywords)

--- a/csvqb/csvqb/models/cube/csvqb/catalog.py
+++ b/csvqb/csvqb/models/cube/csvqb/catalog.py
@@ -47,7 +47,9 @@ class CatalogMetadata(CatalogMetadataBase):
         dataset.comment = self.summary
         dataset.description = self.description
         dataset.license = self.license_uri
+        dataset.creator = self.creator_uri
         dataset.publisher = self.publisher_uri
         dataset.landing_page = self.landing_page_uri
         dataset.themes = set(self.theme_uris)
         dataset.keywords = set(self.keywords)
+        dataset.contact_point = self.public_contact_point_uri

--- a/csvqb/csvqb/models/cube/csvqb/components/observedvalue.py
+++ b/csvqb/csvqb/models/cube/csvqb/components/observedvalue.py
@@ -14,7 +14,7 @@ from csvqb.models.validationerror import ValidationError
 
 class QbObservationValue(MultiQbDataStructureDefinition, ABC):
     def __init__(self, data_type: Optional[str], unit: Optional[QbUnit]):
-        self.data_type: str = data_type if data_type is not None else "number"
+        self.data_type: str = data_type if data_type is not None else "decimal"
         self.unit: Optional[QbUnit] = unit
 
 

--- a/csvqb/csvqb/models/rdf/qbdatasetincatalog.py
+++ b/csvqb/csvqb/models/rdf/qbdatasetincatalog.py
@@ -3,7 +3,7 @@ from sharedmodels.rdf import dcat, qb
 
 class QbDataSetInCatalog(qb.DataSet, dcat.Dataset):
     """
-    Represents both a skos:ConceptScheme and a dcat:Dataset in one node. Means that we don't have to link
+    Represents both a qb:DataSet and a dcat:Dataset in one node. Means that we don't have to link
     between the two.
     """
 

--- a/csvqb/csvqb/models/rdf/qbdatasetincatalog.py
+++ b/csvqb/csvqb/models/rdf/qbdatasetincatalog.py
@@ -1,0 +1,12 @@
+from sharedmodels.rdf import dcat, qb
+
+
+class QbDataSetInCatalog(qb.DataSet, dcat.Dataset):
+    """
+    Represents both a skos:ConceptScheme and a dcat:Dataset in one node. Means that we don't have to link
+    between the two.
+    """
+
+    def __init__(self, uri: str):
+        qb.DataSet.__init__(self, uri)
+        dcat.Dataset.__init__(self, uri)

--- a/csvqb/csvqb/tests/behaviour/qbwriter.feature
+++ b/csvqb/csvqb/tests/behaviour/qbwriter.feature
@@ -1,13 +1,24 @@
-Feature: Test outputting CSV-Ws containing `SKOS:ConceptScheme`s.
+Feature: Test outputting CSV-Ws with Qb flavouring.
 
-  Scenario: A Single-measure QbCube should generate appropriate DCAT Metadata
+  Scenario: A QbCube should generate appropriate DCAT Metadata
     Given a single-measure QbCube named "Some Qube"
     When the cube is serialised to CSV-W
     Then the file at "some-qube.csv" should exist
     And the file at "some-qube.csv-metadata.json" should exist
     And csvlint validation of all CSV-Ws should succeed
     And csv2rdf on all CSV-Ws should succeed
-    And the RDF should pass "all" SPARQL tests
-#    And the RDF should contain
-#      """
-#      """
+    And the RDF should contain
+      """
+        <file:/tmp/some-qube.csv#dataset> a <http://www.w3.org/ns/dcat#Dataset>;
+          <http://purl.org/dc/terms/description> "Description"@en;
+          <http://purl.org/dc/terms/license> <http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/>;
+          <http://purl.org/dc/terms/creator> <https://www.gov.uk/government/organisations/office-for-national-statistics>;
+          <http://purl.org/dc/terms/publisher> <https://www.gov.uk/government/organisations/office-for-national-statistics>;
+          <http://purl.org/dc/terms/title> "Some Qube"@en;
+          <http://www.w3.org/2000/01/rdf-schema#comment> "Summary"@en;
+          <http://www.w3.org/2000/01/rdf-schema#label> "Some Qube"@en;
+          <http://www.w3.org/ns/dcat#keyword> "Key word one"@en, "Key word two"@en;
+          <http://www.w3.org/ns/dcat#landingPage> <http://example.org/landing-page>;
+          <http://www.w3.org/ns/dcat#theme> <http://gss-data.org.uk/def/gdp#some-test-theme>;
+          <http://www.w3.org/ns/dcat#contactPoint> <mailto:something@example.org>.
+      """

--- a/csvqb/csvqb/tests/behaviour/qbwriter.feature
+++ b/csvqb/csvqb/tests/behaviour/qbwriter.feature
@@ -1,0 +1,13 @@
+Feature: Test outputting CSV-Ws containing `SKOS:ConceptScheme`s.
+
+  Scenario: A Single-measure QbCube should generate appropriate DCAT Metadata
+    Given a single-measure QbCube named "Some Qube"
+    When the cube is serialised to CSV-W
+    Then the file at "some-qube.csv" should exist
+    And the file at "some-qube.csv-metadata.json" should exist
+    And csvlint validation of all CSV-Ws should succeed
+    And csv2rdf on all CSV-Ws should succeed
+    And the RDF should pass "all" SPARQL tests
+#    And the RDF should contain
+#      """
+#      """

--- a/csvqb/csvqb/tests/behaviour/skoscodelists.feature
+++ b/csvqb/csvqb/tests/behaviour/skoscodelists.feature
@@ -10,31 +10,31 @@ Feature: Test outputting CSV-Ws containing `SKOS:ConceptScheme`s.
     And the RDF should pass "skos" SPARQL tests
     And the RDF should contain
       """
-        @prefix : <file:/tmp/basic-code-list.csv#>.
-        @prefix concept: <file:/tmp/basic-code-list.csv#concept/>.
+        @prefix concept: <file:/tmp/basic-code-list.csv#concept/basic-code-list/>.
 
-        :scheme a <http://www.w3.org/2004/02/skos/core#ConceptScheme>,
+        <file:/tmp/basic-code-list.csv#scheme/basic-code-list> a <http://www.w3.org/2004/02/skos/core#ConceptScheme>,
           <http://www.w3.org/ns/dcat#Dataset>, <http://www.w3.org/ns/dcat#Resource>;
         <http://purl.org/dc/terms/license> <http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/>;
         <http://purl.org/dc/terms/publisher> <https://www.gov.uk/government/organisations/office-for-national-statistics>;
+        <http://purl.org/dc/terms/creator> <https://www.gov.uk/government/organisations/office-for-national-statistics>;
         <http://purl.org/dc/terms/title> "Basic Code-list"@en;
         <http://www.w3.org/2000/01/rdf-schema#label> "Basic Code-list"@en;
         <http://www.w3.org/2000/01/rdf-schema#comment> "Summary"@en;
         <http://purl.org/dc/terms/description> "Description"@en;
-        <http://www.w3.org/2000/01/rdf-schema#seeAlso> :scheme;
         <http://www.w3.org/ns/dcat#keyword> "Key word one"@en, "Key word two"@en;
         <http://www.w3.org/ns/dcat#landingPage> <http://example.org/landing-page>;
-        <http://www.w3.org/ns/dcat#theme> <http://gss-data.org.uk/def/gdp#some-test-theme> .
+        <http://www.w3.org/ns/dcat#theme> <http://gss-data.org.uk/def/gdp#some-test-theme>;
+        <http://www.w3.org/ns/dcat#contactPoint> <mailto:something@example.org>.
 
         concept:1st-concept <http://www.w3.org/2000/01/rdf-schema#comment> "This is the first concept.";
         <http://www.w3.org/2000/01/rdf-schema#label> "First Concept";
-        <http://www.w3.org/2004/02/skos/core#inScheme> :scheme;
+        <http://www.w3.org/2004/02/skos/core#inScheme> <file:/tmp/basic-code-list.csv#scheme/basic-code-list>;
         <http://www.w3.org/2004/02/skos/core#notation> "1st-concept";
         <http://www.w3.org/ns/ui#sortPriority> 0 .
 
         concept:second-concept <http://www.w3.org/2000/01/rdf-schema#label> "Second Concept";
         <http://www.w3.org/2004/02/skos/core#broader> concept:1st-concept;
-        <http://www.w3.org/2004/02/skos/core#inScheme> :scheme;
+        <http://www.w3.org/2004/02/skos/core#inScheme> <file:/tmp/basic-code-list.csv#scheme/basic-code-list>;
         <http://www.w3.org/2004/02/skos/core#notation> "second-concept";
         <http://www.w3.org/ns/ui#sortPriority> 20 .
       """

--- a/csvqb/csvqb/tests/behaviour/steps/qbwriter.py
+++ b/csvqb/csvqb/tests/behaviour/steps/qbwriter.py
@@ -1,0 +1,47 @@
+import pandas as pd
+from behave import Given, When
+
+
+from csvqb.models.cube import *
+from csvqb.writers.qbwriter import QbWriter
+from devtools.behave.file import get_context_temp_dir_path
+
+
+@Given('a single-measure QbCube named "{cube_name}"')
+def step_impl(context, cube_name: str):
+    metadata = CatalogMetadata(
+        cube_name,
+        summary="Summary",
+        description="Description",
+        creator_uri="https://www.gov.uk/government/organisations/office-for-national-statistics",
+        publisher_uri="https://www.gov.uk/government/organisations/office-for-national-statistics",
+        theme_uris=["http://gss-data.org.uk/def/gdp#some-test-theme"],
+        keywords=["Key word one", "Key word two"],
+        landing_page_uri="http://example.org/landing-page",
+        license_uri="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+        public_contact_point_uri="something@example.org",
+    )
+
+    data = pd.DataFrame(
+        {"A": ["a", "b", "c"], "D": ["e", "f", "g"], "Value": [1, 2, 3]}
+    )
+
+    columns = [
+        QbColumn("A", NewQbDimension.from_data("A code list", data["A"])),
+        QbColumn("D", NewQbDimension.from_data("D code list", data["D"])),
+        QbColumn(
+            "Value",
+            QbSingleMeasureObservationValue(
+                NewQbMeasure("Some Measure"), NewQbUnit("Some Unit")
+            ),
+        ),
+    ]
+
+    context.cube = Cube(metadata, data, columns)
+
+
+@When("the cube is serialised to CSV-W")
+def step_impl(context):
+    writer = QbWriter(context.cube)
+    temp_dir = get_context_temp_dir_path(context)
+    writer.write(temp_dir)

--- a/csvqb/csvqb/tests/behaviour/steps/qbwriter.py
+++ b/csvqb/csvqb/tests/behaviour/steps/qbwriter.py
@@ -19,7 +19,7 @@ def step_impl(context, cube_name: str):
         keywords=["Key word one", "Key word two"],
         landing_page_uri="http://example.org/landing-page",
         license_uri="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
-        public_contact_point_uri="something@example.org",
+        public_contact_point_uri="mailto:something@example.org",
     )
 
     data = pd.DataFrame(

--- a/csvqb/csvqb/tests/behaviour/steps/skoscodelists.py
+++ b/csvqb/csvqb/tests/behaviour/steps/skoscodelists.py
@@ -18,7 +18,7 @@ def step_impl(context, code_list_name: str):
         keywords=["Key word one", "Key word two"],
         landing_page_uri="http://example.org/landing-page",
         license_uri="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
-        public_contact_point_uri="something@example.org",
+        public_contact_point_uri="mailto:something@example.org",
     )
 
     context.code_list = NewQbCodeList(

--- a/csvqb/csvqb/tests/unit/utils/uritests.py
+++ b/csvqb/csvqb/tests/unit/utils/uritests.py
@@ -1,0 +1,29 @@
+import pytest
+
+from csvqb.utils.uri import get_last_uri_part, csvw_column_name_safe, looks_like_uri
+
+
+def test_uri_last_part():
+    assert "dataset-name#something" == get_last_uri_part(
+        "http://gss-data.org.uk/data/stuff/dataset-name#something"
+    )
+
+
+def test_csvw_column_name():
+    assert "some_random_column_name" == csvw_column_name_safe(
+        "Some Random Column //+Name"
+    )
+    assert "something_else" == csvw_column_name_safe("Something-else")
+
+
+def test_looks_like_uri():
+    assert looks_like_uri("https://some-domain.org")
+    assert looks_like_uri("http://some-domain.org/some-stuff/other-stuff")
+    assert looks_like_uri("ftp://some-domain.org")
+    assert looks_like_uri("somescheme:somevalue")
+
+    assert not looks_like_uri("somevalue/cheese")
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/csvqb/csvqb/utils/dict.py
+++ b/csvqb/csvqb/utils/dict.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Callable
+from typing import Any, Optional, Callable, List, Dict
 import rdflib
 import json
 
@@ -18,10 +18,10 @@ def get_with_func_or_none(
     return func(d[prop_name]) if d.get(prop_name) is not None else None
 
 
-def rdf_resource_to_json_ld_dict(resource: NewResource) -> dict:
+def rdf_resource_to_json_ld(resource: NewResource) -> List[Dict[str, Any]]:
     """
-    Converts a `NewResource` RDF model into a dictionary containing json-ld
+    Converts a `NewResource` RDF model into a list of dictionaries containing json-ld
     """
     g = rdflib.Graph()
     resource.to_graph(g)
-    return json.loads(g.serialize(format="json-ld") or "{}")
+    return json.loads(g.serialize(format="json-ld") or "[]")

--- a/csvqb/csvqb/utils/uri.py
+++ b/csvqb/csvqb/utils/uri.py
@@ -1,5 +1,6 @@
 import re
 from unidecode import unidecode
+from urllib.parse import urlparse
 
 
 multiple_non_word_chars_regex = re.compile(r"[^\w]+")
@@ -27,3 +28,8 @@ def get_last_uri_part(uri: str) -> str:
         return maybe_match.group(1)
 
     raise Exception("Could not match last URI part")
+
+
+def looks_like_uri(maybe_uri: str) -> bool:
+    parse_result = urlparse(maybe_uri)
+    return parse_result.scheme != ""

--- a/csvqb/csvqb/writers/qbwriter.py
+++ b/csvqb/csvqb/writers/qbwriter.py
@@ -13,15 +13,14 @@ from sharedmodels.rdf.resource import (
 
 
 from csvqb.models.cube import *
-from csvqb.utils.uri import get_last_uri_part, csvw_column_name_safe
+from csvqb.utils.uri import get_last_uri_part, csvw_column_name_safe, looks_like_uri
 from csvqb.utils.qb.cube import get_columns_of_dsd_type
-from csvqb.utils.dict import rdf_resource_to_json_ld_dict
+from csvqb.utils.dict import rdf_resource_to_json_ld
 from .skoscodelistwriter import SkosCodeListWriter
 from .writerbase import WriterBase
+from ..models.rdf.qbdatasetincatalog import QbDataSetInCatalog
 
 VIRT_UNIT_COLUMN_NAME = "virt_unit"
-
-MkDocRelUri = Callable[[str], str]
 
 
 class QbWriter(WriterBase):
@@ -44,23 +43,20 @@ class QbWriter(WriterBase):
         # todo: Add `aboutUrl` mapping based on all of dimensions (in some consistent ordering).
         # todo: Unit multiplier functionality hasn't been output.
 
-        dataset_definition = self._generate_qb_metadata_dict()
-
-        # todo: Need to decide on the catalogue metadata's structure and add it to `rdfs:seeAlso` below.
-
         csvw_metadata = {
             "@context": "http://www.w3.org/ns/csvw",
             "@id": self._doc_rel_uri("dataset"),
             "tables": tables,
-            "rdfs:label": self.cube.metadata.title,
-            "dc:title": self.cube.metadata.title,
-            "rdfs:comment": self.cube.metadata.summary,
-            "dc:description": self.cube.metadata.description,
-            "rdfs:seeAlso": dataset_definition,
+            "rdfs:seeAlso": rdf_resource_to_json_ld(
+                self._generate_qb_dataset_dsd_definitions()
+            ),
         }
 
         with open(output_folder / f"{self.csv_file_name}-metadata.json", "w+") as f:
             json.dump(csvw_metadata, f, indent=4)
+
+        if self.cube.data is not None:
+            self.cube.data.to_csv(output_folder / self.csv_file_name, index=False)
 
     def _doc_rel_uri(self, uri_fragment: str) -> str:
         """
@@ -120,12 +116,13 @@ class QbWriter(WriterBase):
             )
         return virtual_columns
 
-    def _generate_qb_metadata_dict(self) -> dict:
-        dataset = self._generate_qb_dataset_dsd_definitions()
-        return rdf_resource_to_json_ld_dict(dataset)
+    def _get_qb_dataset_with_catalog_metadata(self) -> QbDataSetInCatalog:
+        qb_dataset_with_metadata = QbDataSetInCatalog(self._doc_rel_uri("dataset"))
+        self.cube.metadata.configure_dcat_dataset(qb_dataset_with_metadata)
+        return qb_dataset_with_metadata
 
     def _generate_qb_dataset_dsd_definitions(self):
-        dataset = qb.DataSet(self._doc_rel_uri("dataset"))
+        dataset = self._get_qb_dataset_with_catalog_metadata()
         dataset.structure = qb.DataStructureDefinition(self._doc_rel_uri("structure"))
         for column in self.cube.columns:
             if isinstance(column, QbColumn):
@@ -139,6 +136,7 @@ class QbWriter(WriterBase):
                     component_properties_for_col
                 )
                 dataset.structure.components |= set(component_specs_for_col)
+
         return dataset
 
     def _get_qb_component_specs_for_col(
@@ -160,6 +158,21 @@ class QbWriter(WriterBase):
             return self._get_qb_obs_val_specifications(component)
         else:
             raise Exception(f"Unhandled component type {type(component)}")
+
+    def _get_obs_val_data_type(self) -> str:
+        observation_value_columns = get_columns_of_dsd_type(
+            self.cube, QbObservationValue
+        )
+        # Given the data shapes we accept as input, there should always be one (and only one) Observation Value
+        # column in a cube.
+        observation_value_column = observation_value_columns[0]
+        data_type = observation_value_column.component.data_type
+        if looks_like_uri(data_type):
+            # is already a full URI
+            return data_type
+        else:
+            # Is not a URI so it should be xsd:`data_type`.
+            return str(rdflib.XSD[data_type])
 
     def _get_qb_units_column_specification(
         self, column_name_uri_safe: str
@@ -245,6 +258,7 @@ class QbWriter(WriterBase):
                 measure.parent_measure_uri
             )
             component.measure.source = maybe_existing_resource(measure.source_uri)
+            component.measure.range = ExistingResource(self._get_obs_val_data_type())
             component.componentProperties.add(component.measure)
             return component
         else:

--- a/csvqb/csvqb/writers/qbwriter.py
+++ b/csvqb/csvqb/writers/qbwriter.py
@@ -494,7 +494,7 @@ class QbWriter(WriterBase):
         return "{+" + csvw_column_name_safe(column.uri_safe_identifier) + "}"
 
     def _get_new_code_list_scheme_uri(self, code_list: NewQbCodeList) -> str:
-        return self._doc_rel_uri(f"scheme/{code_list.metadata.uri_safe_identifier}")
+        return f"./{code_list.metadata.uri_safe_identifier}.csv#scheme/{code_list.metadata.uri_safe_identifier}"
 
     external_code_list_pattern = re.compile("^(.*)/concept-scheme/(.*)$")
     dataset_local_code_list_pattern = re.compile("^(.*)#scheme/(.*)$")

--- a/csvqb/csvqb/writers/skoscodelistwriter.py
+++ b/csvqb/csvqb/writers/skoscodelistwriter.py
@@ -49,8 +49,13 @@ class SkosCodeListWriter(WriterBase):
         return csvw_metadata, data
 
     def _get_csvw_metadata(self) -> dict:
-        additional_metadata = self._get_catalog_metadata()
-
+        scheme_uri = self._doc_rel_uri(
+            f"scheme/{self.new_code_list.metadata.uri_safe_identifier}"
+        )
+        additional_metadata = self._get_catalog_metadata(scheme_uri)
+        concept_base_uri = self._doc_rel_uri(
+            f"concept/{self.new_code_list.metadata.uri_safe_identifier}/"
+        )
         csvw_columns = [
             {
                 "titles": "Label",
@@ -69,7 +74,7 @@ class SkosCodeListWriter(WriterBase):
                 "name": "parent_notation",
                 "required": False,
                 "propertyUrl": "skos:broader",
-                "valueUrl": self._doc_rel_uri("concept/{+parent_notation}"),
+                "valueUrl": concept_base_uri + "{+parent_notation}",
             },
             {
                 "titles": "Sort Priority",
@@ -89,27 +94,25 @@ class SkosCodeListWriter(WriterBase):
                 "name": "virt_inScheme",
                 "required": False,
                 "propertyUrl": "skos:inScheme",
-                "valueUrl": self._doc_rel_uri("scheme"),
+                "valueUrl": scheme_uri,
             },
         ]
 
         csvw_metadata = {
             "@context": "http://www.w3.org/ns/csvw",
-            "@id": self._doc_rel_uri("scheme"),
+            "@id": scheme_uri,
             "url": self.csv_file_name,
             "tableSchema": {
                 "columns": csvw_columns,
-                "aboutUrl": self._doc_rel_uri("concept/{+notation}"),
+                "aboutUrl": concept_base_uri + "{+notation}",
             },
             "rdfs:seeAlso": rdf_resource_to_json_ld(additional_metadata),
         }
 
         return csvw_metadata
 
-    def _get_catalog_metadata(self) -> ConceptSchemeInCatalog:
-        concept_scheme_with_metadata = ConceptSchemeInCatalog(
-            self._doc_rel_uri("scheme")
-        )
+    def _get_catalog_metadata(self, scheme_uri: str) -> ConceptSchemeInCatalog:
+        concept_scheme_with_metadata = ConceptSchemeInCatalog(scheme_uri)
         self.new_code_list.metadata.configure_dcat_dataset(concept_scheme_with_metadata)
         return concept_scheme_with_metadata
 

--- a/csvqb/csvqb/writers/skoscodelistwriter.py
+++ b/csvqb/csvqb/writers/skoscodelistwriter.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 
 from csvqb.models.cube.csvqb.components.codelist import NewQbCodeList
-from csvqb.utils.dict import rdf_resource_to_json_ld_dict
+from csvqb.utils.dict import rdf_resource_to_json_ld
 from csvqb.models.rdf.conceptschemeincatalog import ConceptSchemeInCatalog
 from csvqb.writers.writerbase import WriterBase
 
@@ -101,28 +101,17 @@ class SkosCodeListWriter(WriterBase):
                 "columns": csvw_columns,
                 "aboutUrl": self._doc_rel_uri("concept/{+notation}"),
             },
-            "rdfs:seeAlso": rdf_resource_to_json_ld_dict(additional_metadata),
+            "rdfs:seeAlso": rdf_resource_to_json_ld(additional_metadata),
         }
 
         return csvw_metadata
 
     def _get_catalog_metadata(self) -> ConceptSchemeInCatalog:
-        dt_now = datetime.datetime.now()
-        metadata = self.new_code_list.metadata
-
-        concept_scheme = ConceptSchemeInCatalog(self._doc_rel_uri("scheme"))
-        concept_scheme.label = concept_scheme.title = metadata.title
-        concept_scheme.issued = metadata.issued or dt_now
-        concept_scheme.modified = dt_now
-        concept_scheme.comment = metadata.summary
-        concept_scheme.description = metadata.description
-        concept_scheme.license = metadata.license_uri
-        concept_scheme.publisher = metadata.publisher_uri
-        concept_scheme.landing_page = metadata.landing_page_uri
-        concept_scheme.themes = set(metadata.theme_uris)
-        concept_scheme.keywords = set(metadata.keywords)
-
-        return concept_scheme
+        concept_scheme_with_metadata = ConceptSchemeInCatalog(
+            self._doc_rel_uri("scheme")
+        )
+        self.new_code_list.metadata.configure_dcat_dataset(concept_scheme_with_metadata)
+        return concept_scheme_with_metadata
 
     def _get_code_list_data(self) -> pd.DataFrame:
         return pd.DataFrame(

--- a/devtools/devtools/behave/csv2rdf.py
+++ b/devtools/devtools/behave/csv2rdf.py
@@ -57,7 +57,7 @@ def step_impl(context):
 
     for file in csvw_metadata_files:
         exit_code, logs, ttl_out = _run_csv2rdf(context, temp_dir / file)
-        nose.assert_equal(exit_code, 0)
+        assert exit_code == 0
 
         context.turtle += ttl_out
 

--- a/devtools/devtools/behave/csv2rdf.py
+++ b/devtools/devtools/behave/csv2rdf.py
@@ -37,8 +37,6 @@ def _run_csv2rdf(context, metadata_file_path: Path) -> Tuple[int, str, Optional[
         else:
             ttl_out = ""
 
-        context.turtle = ttl_out
-
     return exit_code, csv2rdf.logs().decode("utf-8"), ttl_out
 
 

--- a/devtools/devtools/behave/csv2rdf.py
+++ b/devtools/devtools/behave/csv2rdf.py
@@ -2,7 +2,6 @@
 behave functionality to run csv-lint on some output
 """
 from behave import step
-import pytest
 from pathlib import Path
 import docker
 import sys
@@ -50,6 +49,19 @@ def step_impl(context, file: str):
     assert exit_code == 0
 
     context.turtle = ttl_out
+
+
+@step("csv2rdf on all CSV-Ws should succeed")
+def step_impl(context):
+    temp_dir = get_context_temp_dir_path(context)
+    csvw_metadata_files = temp_dir.rglob("*.csv-metadata.json")
+    context.turtle = ""
+
+    for file in csvw_metadata_files:
+        exit_code, logs, ttl_out = _run_csv2rdf(context, temp_dir / file)
+        nose.assert_equal(exit_code, 0)
+
+        context.turtle += ttl_out
 
 
 @step('csv2rdf on "{file}" should fail with "{expected}"')

--- a/devtools/devtools/behave/csvlint.py
+++ b/devtools/devtools/behave/csvlint.py
@@ -24,6 +24,14 @@ def _run_csvlint(metadata_file_path: Path) -> Tuple[int, str]:
     return exit_code, csvlint.logs().decode("utf-8")
 
 
+@step("csvlint validation of all CSV-Ws should succeed")
+def step_impl(context):
+    temp_dir = get_context_temp_dir_path(context)
+    for file in temp_dir.rglob("*.csv-metadata.json"):
+        exit_code, logs = _run_csvlint(temp_dir / file)
+        assert exit_code == 0
+
+
 @step('csvlint validation of "{file}" should succeed')
 def step_impl(context, file: str):
     temp_dir = get_context_temp_dir_path(context)

--- a/devtools/devtools/behave/rdf.py
+++ b/devtools/devtools/behave/rdf.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from behave import *
-import pytest
 from rdflib.compare import to_isomorphic, graph_diff
 from rdflib import Graph
 import distutils.util

--- a/sharedmodels/sharedmodels/rdf/qb.py
+++ b/sharedmodels/sharedmodels/rdf/qb.py
@@ -30,7 +30,7 @@ class ComponentProperty(rdf.PropertyWithMetadata):
 class MeasureProperty(ComponentProperty):
     """Measure property - The class of components which represent the measured value of the phenomenon being observed"""
 
-    range: Annotated[Resource[rdfs.Class], Triple(RDFS.range, PropertyStatus.mandatory, URIRef)]
+    range: Annotated[Resource[rdfs.Class], Triple(RDFS.range, PropertyStatus.mandatory, map_resource_to_uri)]
     """range - the `rdfs:range` associated with this measure property. i.e. the value types the measured values can 
     range over."""
 


### PR DESCRIPTION
Adds `dcat:Dataset` class to the `qb:DataSet` with the appropriate metadata which should be enough for PMD's needs.

Closes issue #23. 