### PR TITLE
Issue#62 Test cube validation 

### DIFF
--- a/csvqb/csvqb/models/cube/cube.py
+++ b/csvqb/csvqb/models/cube/cube.py
@@ -33,6 +33,8 @@ class Cube(Generic[TMetadata]):
                 errors.append(
                     ValidationError(f"Duplicate column title '{col.csv_column_title}'")
                 )
+            else:
+                existing_col_titles.add(col.csv_column_title)
 
             maybe_column_data = None
             if self.data is not None:

--- a/csvqb/csvqb/tests/unit/cube/test_cube_errorvalidation.py
+++ b/csvqb/csvqb/tests/unit/cube/test_cube_errorvalidation.py
@@ -1,6 +1,7 @@
-import pytest
-import pandas as pd
 from typing import List
+
+import pandas as pd
+import pytest
 
 from csvqb.models.cube import *
 
@@ -38,8 +39,6 @@ def test_column_title_wrong_error():
     error = validation_errors[0]
     assert "Column 'Some Column Title'" in error.message
 
-# Define a cube with two columns with the same title. Test that a suitable error message is generated on validation.
-
 
 def test_two_column_same_title():
     """
@@ -50,12 +49,12 @@ def test_two_column_same_title():
         "Some Dimension": ["A", "B", "C"]
     })
 
+    metadata = CatalogMetadata("Some Dataset")
     columns: List[CsvColumn] = [
         SuppressedCsvColumn("Some Dimension"),
         SuppressedCsvColumn("Some Dimension")
     ]
 
-    metadata = CatalogMetadata("Some Dataset")
     cube = Cube(metadata, data, columns)
     validation_errors = cube.validate()
 

--- a/csvqb/csvqb/tests/unit/cube/test_cube_errorvalidation.py
+++ b/csvqb/csvqb/tests/unit/cube/test_cube_errorvalidation.py
@@ -19,7 +19,7 @@ def test_column_not_configured_error():
 
     assert len(validation_errors) == 1
     error = validation_errors[0]
-    assert "Some Dimension" in error.message
+    assert "Column 'Some Dimension'" in error.message
 
 
 def test_column_title_wrong_error():
@@ -36,7 +36,32 @@ def test_column_title_wrong_error():
 
     assert len(validation_errors) == 1
     error = validation_errors[0]
-    assert "Some Column Title" in error.message
+    assert "Column 'Some Column Title'" in error.message
+
+# Define a cube with two columns with the same title. Test that a suitable error message is generated on validation.
+
+
+def test_two_column_same_title():
+    """
+    If cube with two columns with the same title is defined, we get an error
+    """
+    data = pd.DataFrame({
+        "Some Dimension": ["A", "B", "C"],
+        "Some Dimension": ["A", "B", "C"]
+    })
+
+    columns: List[CsvColumn] = [
+        SuppressedCsvColumn("Some Dimension"),
+        SuppressedCsvColumn("Some Dimension")
+    ]
+
+    metadata = CatalogMetadata("Some Dataset")
+    cube = Cube(metadata, data, columns)
+    validation_errors = cube.validate()
+
+    assert len(validation_errors) == 1
+    error = validation_errors[0]
+    assert "Duplicate column title 'Some Dimension'" == error.message
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Suitable error message is generated when
1.  A cube with two columns with the same title is defined.
2. Defining a column with a title that doesn't exist in the DataFrame.
3.  A column in input DataFrame doesn't have a column mapping.

#62