### PR TITLE
Issue #108 - Create CLI for csvqb

### DIFF
--- a/csvqb/Pipfile
+++ b/csvqb/Pipfile
@@ -13,6 +13,7 @@ csvwlib-models = {editable = true,path = "./../sharedmodels"}
 rdflib-jsonld = "*"
 pydantic = {editable = true,git = "https://github.com/robons/pydantic.git"}
 click = "*"
+colorama = "*"
 
 [requires]
 python_version = "3.9"

--- a/csvqb/Pipfile
+++ b/csvqb/Pipfile
@@ -12,6 +12,7 @@ pandas = "*"
 csvwlib-models = {editable = true,path = "./../sharedmodels"}
 rdflib-jsonld = "*"
 pydantic = {editable = true,git = "https://github.com/robons/pydantic.git"}
+click = "*"
 
 [requires]
 python_version = "3.9"

--- a/csvqb/Pipfile.lock
+++ b/csvqb/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "793208c80841150bc21bde3d2ccf3d9304a0de10c56904f9f20b58bf4907eeeb"
+            "sha256": "f970a484569236b01bd5ad448637175c64a2d8d944b20c128d516b541296c16a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "click": {
+            "hashes": [
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
+            ],
+            "index": "pypi",
+            "version": "==8.0.1"
+        },
         "csvqb": {
             "editable": true,
             "path": "."
@@ -243,6 +251,7 @@
                 "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
                 "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
             ],
+            "index": "pypi",
             "version": "==8.0.1"
         },
         "colorama": {

--- a/csvqb/Pipfile.lock
+++ b/csvqb/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f970a484569236b01bd5ad448637175c64a2d8d944b20c128d516b541296c16a"
+            "sha256": "5b9d687dcce77feb9d6a4103654a546f312d6baf41fe5dc8ddfd17652b5f11b9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,14 @@
             ],
             "index": "pypi",
             "version": "==8.0.1"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+            ],
+            "index": "pypi",
+            "version": "==0.4.4"
         },
         "csvqb": {
             "editable": true,
@@ -259,6 +267,7 @@
                 "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
                 "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
             ],
+            "index": "pypi",
             "version": "==0.4.4"
         },
         "csvw": {

--- a/csvqb/csvqb/README.md
+++ b/csvqb/csvqb/README.md
@@ -1,0 +1,43 @@
+# CSVqb
+
+A tool to generate qb-flavoured CSV-W cubes from regular CSVs.
+
+## Command Line Interface
+
+```bash
+Usage: csvqb [OPTIONS] COMMAND [ARGS]...
+
+  CSVqb - a tool to generate qb-flavoured CSV-W cubes.
+
+Options:
+  -h, --help  Show this message and exit.
+
+Commands:
+  build  Build a qb-flavoured CSV-W from a tidy CSV.
+```
+
+### Build
+
+Build the qb-flavoured CSV-Ws from an *info.json V1* file.
+
+```bash
+Usage: csvqb build [OPTIONS] TIDY_CSV_PATH
+
+  Build a qb-flavoured CSV-W from a tidy CSV.
+
+Options:
+  -c, --config CONFIG_PATH        Location of the info.json file containing
+                                  the QB column mapping definitions.
+                                  [required]
+  -o, --out OUT_DIR               Location of the CSV-W outputs.  [default:
+                                  out]
+  --fail-when-validation-error / --ignore-validation-errors
+                                  Fail when validation errors occur or ignore
+                                  validation errors and continue generating a
+                                  CSV-W.  [default: fail-when-validation-
+                                  error]
+  --validation-errors-to-file     Save validation errors to an `validation-
+                                  errors.json` file in the output directory.
+                                  [default: False]
+  -h, --help                      Show this message and exit.
+```

--- a/csvqb/csvqb/cli/build.py
+++ b/csvqb/csvqb/cli/build.py
@@ -27,6 +27,7 @@ def build(
     print(f"{Style.DIM}CSV: {csv_path.absolute()}")
     print(f"{Style.DIM}info.json: {info_json.absolute()}")
     data = pd.read_csv(csv_path)
+    assert isinstance(data, pd.DataFrame)
     cube = get_cube_from_info_json(info_json, data)
 
     errors = cube.validate()

--- a/csvqb/csvqb/cli/build.py
+++ b/csvqb/csvqb/cli/build.py
@@ -1,0 +1,55 @@
+"""
+Build Command
+-------------
+
+Build a qb-flavoured CSV-W from an info.json and a tidy CSV.
+"""
+import dataclasses
+import json
+
+from colorama import Fore, Style
+from pathlib import Path
+import pandas as pd
+from typing import Optional
+
+from csvqb.configloaders.infojson import get_cube_from_info_json
+from csvqb.writers.qbwriter import QbWriter
+from csvqb.utils.qb.cube import validate_qb_component_constraints
+
+
+def build(
+    info_json: Path,
+    output_directory: Path,
+    csv_path: Path,
+    fail_when_validation_error_occurs: bool,
+    validation_errors_file_out: Optional[Path],
+):
+    print(f"{Style.DIM}CSV: {csv_path.absolute()}")
+    print(f"{Style.DIM}info.json: {info_json.absolute()}")
+    data = pd.read_csv(csv_path)
+    cube = get_cube_from_info_json(info_json, data)
+
+    errors = cube.validate()
+    errors += validate_qb_component_constraints(cube)
+
+    if not output_directory.exists():
+        print(f"Creating output directory {output_directory.absolute()}")
+        output_directory.mkdir()
+
+    if len(errors) > 0:
+        for error in errors:
+            print(
+                f"{Fore.RED + Style.BRIGHT}Validation Error: {Style.NORMAL + error.message}"
+            )
+
+        if validation_errors_file_out is not None:
+            with open(validation_errors_file_out, "w+") as f:
+                json.dump([dataclasses.asdict(e) for e in errors], f, indent=4)
+
+        if fail_when_validation_error_occurs:
+            exit(1)
+
+    qb_writer = QbWriter(cube)
+    qb_writer.write(output_directory)
+
+    print(f"{Fore.GREEN + Style.BRIGHT}Build Complete")

--- a/csvqb/csvqb/cli/entrypoint.py
+++ b/csvqb/csvqb/cli/entrypoint.py
@@ -1,0 +1,68 @@
+"""
+CLI
+---
+
+The *Command Line Interface* for :mod:`csvqb`.
+"""
+import click
+from pathlib import Path
+import colorama
+
+from .build import build
+
+
+@click.group(context_settings=dict(help_option_names=["-h", "--help"]))
+def entry_point():
+    """
+    CSVqb - a tool to generate qb-flavoured CSV-W cubes.
+    """
+    colorama.init(autoreset=True, wrap=True)
+
+
+@entry_point.command("build")
+@click.option(
+    "--config",
+    "-c",
+    help="Location of the info.json file containing the QB column mapping definitions.",
+    type=click.Path(exists=True, path_type=Path, file_okay=True, dir_okay=False),
+    required=True,
+    metavar="CONFIG_PATH",
+)
+@click.option(
+    "--out",
+    "-o",
+    help="Location of the CSV-W outputs.",
+    default="./out",
+    show_default=True,
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    metavar="OUT_DIR",
+)
+@click.option(
+    "--fail-when-validation-error/--ignore-validation-errors",
+    help="Fail when validation errors occur or ignore validation errors and continue generating a CSV-W.",
+    default=True,
+    show_default=True,
+)
+@click.option(
+    "--validation-errors-to-file",
+    "validation_errors_to_file",
+    help="Save validation errors to an `validation-errors.json` file in the output directory.",
+    flag_value=True,
+    default=False,
+    show_default=True,
+)
+@click.argument(
+    "csv", type=click.Path(exists=True, path_type=Path), metavar="TIDY_CSV_PATH"
+)
+def build_command(
+    config: Path,
+    out: Path,
+    csv: Path,
+    fail_when_validation_error: bool,
+    validation_errors_to_file: bool,
+):
+    """Build a qb-flavoured CSV-W from a tidy CSV."""
+    validation_errors_file_out = (
+        out / "validation-errors.json" if validation_errors_to_file else None
+    )
+    build(config, out, csv, fail_when_validation_error, validation_errors_file_out)

--- a/csvqb/csvqb/configloaders/infojson.py
+++ b/csvqb/csvqb/configloaders/infojson.py
@@ -122,7 +122,9 @@ def _columns_from_info_json(
 ) -> List[CsvColumn]:
     defined_columns: List[CsvColumn] = []
 
-    column_titles_in_data: List[str] = [str(title) for title in data.columns]
+    column_titles_in_data: List[str] = [
+        str(title) for title in data.columns  # type: ignore
+    ]
     for col_title in column_titles_in_data:
         maybe_config = column_mappings.get(col_title)
         defined_columns.append(

--- a/csvqb/csvqb/configloaders/infojson.py
+++ b/csvqb/csvqb/configloaders/infojson.py
@@ -58,13 +58,7 @@ def get_cube_from_info_json(
     if config is None:
         raise Exception(f"Config not found for cube with id '{cube_id}'")
 
-    cube = _from_info_json_dict(config, data)
-    validation_errors = validate_qb_component_constraints(cube)
-    for error in validation_errors:
-        # todo: Do something better with errors?
-        print(f"ERROR: {error.message}")
-
-    return cube
+    return _from_info_json_dict(config, data)
 
 
 def _override_config_for_cube_id(config: dict, cube_id: str) -> Optional[dict]:
@@ -128,11 +122,18 @@ def _columns_from_info_json(
 ) -> List[CsvColumn]:
     defined_columns: List[CsvColumn] = []
 
-    for col_title in list(data.columns):
-        col_title = str(col_title)
+    column_titles_in_data: List[str] = [str(title) for title in data.columns]
+    for col_title in column_titles_in_data:
         maybe_config = column_mappings.get(col_title)
         defined_columns.append(
             _get_column_for_metadata_config(col_title, maybe_config, data[col_title])
+        )
+
+    columns_missing_in_data = set(column_mappings.keys()) - set(column_titles_in_data)
+    for col_title in columns_missing_in_data:
+        config = column_mappings[col_title]
+        defined_columns.append(
+            _get_column_for_metadata_config(col_title, config, pd.Series([1]))
         )
 
     return defined_columns

--- a/csvqb/csvqb/models/cube/cube.py
+++ b/csvqb/csvqb/models/cube/cube.py
@@ -31,6 +31,9 @@ class Cube(Generic[TMetadata], PydanticModel):
             errors += self._validate_columns()
         except Exception as e:
             errors.append(ValidationError(str(e)))
+            errors.append(
+                ValidationError("An error occurred and validation Failed to Complete")
+            )
 
         return errors
 
@@ -50,7 +53,8 @@ class Cube(Generic[TMetadata], PydanticModel):
                 else:
                     errors.append(ColumnNotFoundInDataError(col.csv_column_title))
 
-            errors += col.validate_data(maybe_column_data)
+            if maybe_column_data is not None:
+                errors += col.validate_data(maybe_column_data)
 
         if self.data is not None:
             defined_column_titles = [c.csv_column_title for c in self.columns]

--- a/csvqb/csvqb/models/cube/qb/components/unit.py
+++ b/csvqb/csvqb/models/cube/qb/components/unit.py
@@ -53,13 +53,13 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
     """
     The unit that this new unit is based on.
     
-    Codependent with base_unit_scaling_factor.
+    Codependent with :attr:`base_unit_scaling_factor`.
     """
     base_unit_scaling_factor: Optional[float] = field(default=None, repr=False)
     """
     How to scale the value associated with this unit to map back to the base unit.
     
-    Codependent with base_unit.
+    Codependent with :attr:`base_unit`.
     
     e.g. if the base unit is *meters* and this unit (*kilometers*) has a scaling factor of **1,000**, then you multiply 
     the value in *kilometers* by **1,000** to get the value in *meters*.    
@@ -69,7 +69,7 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
     """
     The URI of the `qudt:QuantityKind` family to which this unit belongs.
     
-    Codependent with si_base_unit_conversion_multiplier. 
+    Codependent with :attr:`si_base_unit_conversion_multiplier`. 
     """
     si_base_unit_conversion_multiplier: Optional[float] = field(
         default=None, repr=False
@@ -77,7 +77,7 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
     """
     Multiply a value by this number to convert between this unit and its corresponding **SI unit**.
 
-    Codependent with qudt_quantity_kind_uri. 
+    Codependent with :attr:`qudt_quantity_kind_uri`. 
        
     See https://github.com/qudt/qudt-public-repo/wiki/User-Guide-for-QUDT#4-conversion-multipliers-in-qudt to understand
     the role of `qudt:conversionMultiplier` before using this. *It may not represent what you think it does.*
@@ -93,6 +93,8 @@ class NewQbUnit(QbUnit, UriIdentifiable, ArbitraryRdf):
             "qudt_quantity_kind_uri": ["si_base_unit_conversion_multiplier"],
         }
     )
+
+    _qudt_quantity_kind_uri_validation = validate_uri("qudt_quantity_kind_uri")
 
     def get_permitted_rdf_fragment_hints(self) -> Set[RdfSerialisationHint]:
         return {RdfSerialisationHint.Unit}

--- a/csvqb/csvqb/tests/behaviour/cli.feature
+++ b/csvqb/csvqb/tests/behaviour/cli.feature
@@ -1,0 +1,41 @@
+Feature: Test the csvqb Command Line Interface.
+
+  Scenario: The csvqb build command should take an info.json and CSV and output CSV-Ws into the default './out' directory.
+    Given the existing test-case file "configloaders/data.csv"
+    And the existing test-case file "configloaders/info.json"
+    When the csvqb CLI is run with "build --config configloaders/info.json configloaders/data.csv"
+    Then the csvqb CLI should succeed
+    And the csvqb CLI should print "Creating output directory"
+    And the file at "out/ons-international-trade-in-services-by-subnational-areas-of-the-uk.csv" should exist
+    And the file at "out/ons-international-trade-in-services-by-subnational-areas-of-the-uk.csv-metadata.json" should exist
+    And the file at "out/validation-errors.json" should not exist
+
+  Scenario: The csvqb build command should not output CSV-Ws when validation errors occur
+    Given the existing test-case file "configloaders/validation-error/data.csv"
+    And the existing test-case file "configloaders/validation-error/info.json"
+    When the csvqb CLI is run with "build --config configloaders/validation-error/info.json configloaders/validation-error/data.csv"
+    Then the csvqb CLI should fail with status code 1
+    And the csvqb CLI should print "Validation Error"
+    And the csvqb CLI should print "Column 'Measure Type' not found in data provided"
+    And the file at "out/validation-error-output.csv" should not exist
+    And the file at "out/validation-error-output.csv-metadata.json" should not exist
+    And the file at "out/validation-errors.json" should not exist
+
+  Scenario: The csvqb build command should output validation errors to file
+    Given the existing test-case file "configloaders/validation-error/data.csv"
+    And the existing test-case file "configloaders/validation-error/info.json"
+    When the csvqb CLI is run with "build --validation-errors-to-file --config configloaders/validation-error/info.json configloaders/validation-error/data.csv"
+    Then the csvqb CLI should fail with status code 1
+    And the file at "out/validation-errors.json" should exist
+    And the validation-errors.json file in the "out" directory should contain
+    """
+      Column 'Measure Type' not found in data provided
+    """
+
+  Scenario: The csvqb build command should still output CSV-Ws if the user overrides validation errors
+    Given the existing test-case file "configloaders/validation-error/data.csv"
+    And the existing test-case file "configloaders/validation-error/info.json"
+    When the csvqb CLI is run with "build --ignore-validation-errors --config configloaders/validation-error/info.json  configloaders/validation-error/data.csv"
+    Then the csvqb CLI should succeed
+    And the file at "out/validation-error-output.csv" should exist
+    And the file at "out/validation-error-output.csv-metadata.json" should exist

--- a/csvqb/csvqb/tests/behaviour/steps/cli.py
+++ b/csvqb/csvqb/tests/behaviour/steps/cli.py
@@ -1,0 +1,59 @@
+from behave import when, then
+import subprocess
+from typing import Tuple
+from devtools.behave.temporarydirectory import get_context_temp_dir_path
+
+
+@when('the csvqb CLI is run with "{arguments}"')
+def step_impl(context, arguments: str):
+    command: str = f"csvqb {arguments.strip()}"
+    (status_code, response) = run_command_in_temp_dir(context, command)
+    context.csvqb_cli_result = (status_code, response)
+
+
+@then("the csvqb CLI should succeed")
+def step_impl(context):
+    (status_code, response) = context.csvqb_cli_result
+    assert status_code == 0, status_code
+    assert "Build Complete" in response, response
+
+
+@then("the csvqb CLI should fail with status code {status_code}")
+def step_impl(context, status_code: str):
+    (status_code, response) = context.csvqb_cli_result
+    assert status_code == int(status_code), status_code
+
+
+@then('the csvqb CLI should print "{printed_text}"')
+def step_impl(context, printed_text: str):
+    (status_code, response) = context.csvqb_cli_result
+    assert printed_text in response, response
+
+
+@then('the validation-errors.json file in the "{out_dir}" directory should contain')
+def step_impl(context, out_dir: str):
+    tmp_dir_path = get_context_temp_dir_path(context)
+    expected_text_contents: str = context.text.strip()
+    validation_errors_file = tmp_dir_path / out_dir / "validation-errors.json"
+    assert validation_errors_file.exists()
+
+    with open(validation_errors_file, "r") as f:
+        file_contents = f.read()
+
+    assert expected_text_contents in file_contents, file_contents
+
+
+def run_command_in_temp_dir(context, command: str) -> Tuple[int, str]:
+    tmp_dir_path = get_context_temp_dir_path(context)
+    process = subprocess.Popen(
+        command,
+        shell=True,
+        cwd=tmp_dir_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    status_code = process.wait()
+    response = process.stdout.read().decode("utf-8") + process.stderr.read().decode(
+        "utf-8"
+    )
+    return status_code, response

--- a/csvqb/csvqb/tests/test-cases/configloaders/validation-error/data.csv
+++ b/csvqb/csvqb/tests/test-cases/configloaders/validation-error/data.csv
@@ -1,0 +1,2 @@
+Period,Location,Flow,Industry Grouping,Marker,Value,Undefined Column
+2020-01,West Midlands,Imports,Barbed Wire,,20,Undefined Column Value

--- a/csvqb/csvqb/tests/test-cases/configloaders/validation-error/info.json
+++ b/csvqb/csvqb/tests/test-cases/configloaders/validation-error/info.json
@@ -1,0 +1,42 @@
+{
+    "id": "validation-error-output",
+    "title": "Validation Error Output",
+    "publisher": "HM Revenue & Customs",
+    "description": "All bulletins provide details on percentage of one litre or less & more than one litre bottles. This information is provided on a yearly basis.",
+    "landingPage": "https://www.gov.uk/government/statistics/bottles-bulletin",
+    "datasetNotes": [
+        "\"UK bottles-bulletin Tables\" Excel file, latest version on page"
+    ],
+    "published": "2019-02-28",
+    "families": [
+        "Trade"
+    ],
+    "extract": {
+        "source": "XLS",
+        "stage": "Done"
+    },
+    "transform": {
+        "airtable": "recys4OhEtE0gE14P",
+        "columns": {
+            "Period": {
+                "parent": "http://purl.org/linked-data/sdmx/2009/dimension#refPeriod",
+                "value": "http://reference.data.gov.uk/id/{+period}"
+            },
+            "Measure Type": {
+                "dimension": "http://purl.org/linked-data/cube#measureType",
+                "value": "http://gss-data.org.uk/def/x/{+measure_type}",
+                "types": ["one-litre-and-less", "more-than-one-litre", "number-of-bottles"]
+            },
+            "Unit": {
+                "attribute": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure",
+                "value": "http://gss-data.org.uk/def/concept/measurement-units/{+unit}"
+            },
+            "Value": {
+                "datatype": "integer"
+            }
+        },
+        "main_issue": 67
+    },
+    "sizingNotes": "",
+    "notes": ""
+}

--- a/csvqb/setup.py
+++ b/csvqb/setup.py
@@ -6,6 +6,7 @@ setup(
         "git+https://github.com/robons/pydantic.git@f0339d2178634bee95d9cc6d4e925415881f9f27#egg=pydantic"
     ],
     install_requires=[
+        "click==8.0.1",
         "isodate==0.6.0",
         "numpy==1.21.0",
         "pandas==1.2.5",
@@ -21,4 +22,5 @@ setup(
     version="0.0.1",
     name="csvqb",
     packages=find_packages(exclude=["tests"]),
+    entry_points={"console_scripts": ["csvqb=csvqb.cli.entrypoint:entry_point"]},
 )

--- a/csvqb/setup.py
+++ b/csvqb/setup.py
@@ -7,6 +7,7 @@ setup(
     ],
     install_requires=[
         "click==8.0.1",
+        "colorama==0.4.4",
         "isodate==0.6.0",
         "numpy==1.21.0",
         "pandas==1.2.5",

--- a/devtools/devtools/behave/file.py
+++ b/devtools/devtools/behave/file.py
@@ -10,8 +10,30 @@ import shutil
 from .temporarydirectory import get_context_temp_dir_path
 
 
-@Given('the existing test-case files "{file}"')
+@Given('the existing test-case file "{file}"')
 def step_impl(context, file):
+    test_cases_dir = _get_test_cases_dir()
+    test_case_file = test_cases_dir / file
+
+    if not test_case_file.exists():
+        raise Exception(f"Could not find test-case file {file}")
+
+    temp_dir = get_context_temp_dir_path(context)
+    output_file_path = temp_dir.joinpath(test_case_file.relative_to(test_cases_dir))
+
+    _ensure_directory_hierarchy_exists(output_file_path.parent)
+
+    shutil.copy(test_case_file, output_file_path)
+
+
+def _ensure_directory_hierarchy_exists(directory: Path):
+    if not directory.exists():
+        _ensure_directory_hierarchy_exists(directory.parent)
+        directory.mkdir()
+
+
+@Given('the existing test-case files "{files_glob}"')
+def step_impl(context, files_glob: str):
     test_cases_dir = _get_test_cases_dir()
 
     matching_files = list(test_cases_dir.rglob(f"**/{file}"))
@@ -32,7 +54,7 @@ def step_impl(context, file):
 @then('the file at "{file}" should exist')
 def step_impl(context, file):
     temp_dir = get_context_temp_dir_path(context)
-    assert (temp_dir / file).exists()
+    assert (temp_dir / file).exists(), file
 
 
 def _get_test_cases_dir(start_dir: Path = Path(".")):

--- a/devtools/devtools/behave/file.py
+++ b/devtools/devtools/behave/file.py
@@ -36,9 +36,9 @@ def _ensure_directory_hierarchy_exists(directory: Path):
 def step_impl(context, files_glob: str):
     test_cases_dir = _get_test_cases_dir()
 
-    matching_files = list(test_cases_dir.rglob(f"**/{file}"))
+    matching_files = list(test_cases_dir.rglob(f"**/{files_glob}"))
     if len(matching_files) == 0:
-        raise Exception(f"Could not find test-case file {file}")
+        raise Exception(f"Could not find test-case file(s) {files_glob}")
 
     temp_dir = get_context_temp_dir_path(context)
     for file in matching_files:


### PR DESCRIPTION
Satisfies issue #108.

## Command Line Interface

```bash
Usage: csvqb [OPTIONS] COMMAND [ARGS]...
  CSVqb - a tool to generate qb-flavoured CSV-W cubes.
Options:
  -h, --help  Show this message and exit.
Commands:
  build  Build a qb-flavoured CSV-W from a tidy CSV.
```

### Build

Build the qb-flavoured CSV-Ws from an *info.json V1* file.

```bash
Usage: csvqb build [OPTIONS] TIDY_CSV_PATH
  Build a qb-flavoured CSV-W from a tidy CSV.
Options:
  -c, --config CONFIG_PATH        Location of the info.json file containing
                                  the QB column mapping definitions.
                                  [required]
  -o, --out OUT_DIR               Location of the CSV-W outputs.  [default:
                                  out]
  --fail-when-validation-error / --ignore-validation-errors
                                  Fail when validation errors occur or ignore
                                  validation errors and continue generating a
                                  CSV-W.  [default: fail-when-validation-
                                  error]
  --validation-errors-to-file     Save validation errors to an `validation-
                                  errors.json` file in the output directory.
                                  [default: False]
  -h, --help                      Show this message and exit.
```

example:

```bash
csvqb build --config info.json data.csv
```

Outputs resulting CSV-Ws into the `./out` directory (which is created if it does not already exist).

![image](https://user-images.githubusercontent.com/73846016/131110151-8f3380da-f8af-443e-a7fb-b6e80fb447eb.png)
