### PR TITLE
Issue #28 - Allowing CatalogMetadata Serialisation/Deserialisation to/from JSON

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,11 @@ pipeline {
         stage('Setup') {
             steps {
                 script {
+                    sh 'find . -user root -name \'*\' | xargs chmod ugo+rw'
+                    cleanWs deleteDirs: true, patterns: [[pattern: ".venv", type: "EXCLUDE"]]
+
                     // Clean up any files lying about after the previous build. Jenkins has trouble deleting files given that our containers run as root.
-                    sh "git clean -fxd" 
+                    // sh "git clean -fxd" 
 
                     dir("devtools") {
                         sh "PIPENV_VENV_IN_PROJECT=true pipenv sync --dev"
@@ -168,7 +171,7 @@ pipeline {
         success {
             script {
                 sh 'find . -user root -name \'*\' | xargs chmod ugo+rw'
-                cleanWs deleteDirs: true, patterns: [[pattern: '.', type: 'INCLUDE'], [pattern: ".venv", type: "EXCLUDE"]]
+                // cleanWs deleteDirs: true, patterns: [[pattern: '.', type: 'INCLUDE'], [pattern: ".venv", type: "EXCLUDE"]]
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                         // Patch behave so that it can output the correct format for the Jenkins cucumber tool.
                         def venv_location = sh script: "pipenv --venv", returnStdout: true
                         venv_location = venv_location.trim()
-                        sh "patch -t -d \"${venv_location}/lib/python3.9/site-packages/behave/formatter\" -p1 < /cucumber-format.patch"
+                        sh "patch -f -d \"${venv_location}/lib/python3.9/site-packages/behave/formatter\" -p1 < /cucumber-format.patch"
                     }
 
                     dir("csvqb") {
@@ -33,7 +33,7 @@ pipeline {
                         // Patch behave so that it can output the correct format for the Jenkins cucumber tool.
                         def venv_location = sh script: "pipenv --venv", returnStdout: true
                         venv_location = venv_location.trim()
-                        sh "patch -t -d \"${venv_location}/lib/python3.9/site-packages/behave/formatter\" -p1 < /cucumber-format.patch"
+                        sh "patch -f -d \"${venv_location}/lib/python3.9/site-packages/behave/formatter\" -p1 < /cucumber-format.patch"
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,7 +168,7 @@ pipeline {
         success {
             script {
                 sh 'chmod -R ugo+rw .'
-                cleanWs deleteDirs: true, patterns: [[pattern: "**/.venv/*", type: "EXCLUDE"]]
+                cleanWs deleteDirs: true, patterns: [[pattern: "**/.venv/*", type: "EXCLUDE"], [pattern: "**/.venv/**", type: "EXCLUDE"], [pattern: "**/.venv/**/*", type: "EXCLUDE"]]
            }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                         // Patch behave so that it can output the correct format for the Jenkins cucumber tool.
                         def venv_location = sh script: "pipenv --venv", returnStdout: true
                         venv_location = venv_location.trim()
-                        sh "patch -d \"${venv_location}/lib/python3.9/site-packages/behave/formatter\" -p1 < /cucumber-format.patch"
+                        sh "patch -t -d \"${venv_location}/lib/python3.9/site-packages/behave/formatter\" -p1 < /cucumber-format.patch"
                     }
 
                     dir("csvqb") {
@@ -33,7 +33,7 @@ pipeline {
                         // Patch behave so that it can output the correct format for the Jenkins cucumber tool.
                         def venv_location = sh script: "pipenv --venv", returnStdout: true
                         venv_location = venv_location.trim()
-                        sh "patch -d \"${venv_location}/lib/python3.9/site-packages/behave/formatter\" -p1 < /cucumber-format.patch"
+                        sh "patch -t -d \"${venv_location}/lib/python3.9/site-packages/behave/formatter\" -p1 < /cucumber-format.patch"
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,8 @@ pipeline {
         stage('Setup') {
             steps {
                 script {
-                    sh 'find . -user root -name \'*\' | xargs chmod ugo+rw'
-                    cleanWs deleteDirs: true, patterns: [[pattern: ".venv", type: "EXCLUDE"]]
+                    sh 'find $(pwd) -user root -name * | xargs chmod ugo+rw'
+                    cleanWs deleteDirs: true, patterns: [[pattern: "**/.venv", type: "EXCLUDE"]]
 
                     // Clean up any files lying about after the previous build. Jenkins has trouble deleting files given that our containers run as root.
                     // sh "git clean -fxd" 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,9 +9,6 @@ pipeline {
         stage('Setup') {
             steps {
                 script {
-                    sh 'chmod -R ugo+rw .'
-                    cleanWs deleteDirs: true, patterns: [[pattern: "**/.venv", type: "EXCLUDE"]]
-
                     // Clean up any files lying about after the previous build. Jenkins has trouble deleting files given that our containers run as root.
                     // sh "git clean -fxd" 
 
@@ -142,7 +139,7 @@ pipeline {
     post {
         always {
             script {
-                sh 'find . -user root -name \'*\' | xargs chmod ugo+rw'
+                sh 'chmod -R ugo+rw .'
 
                 try {
                     unstash name: "test-results"
@@ -170,9 +167,9 @@ pipeline {
         }
         success {
             script {
-                sh 'find . -user root -name \'*\' | xargs chmod ugo+rw'
-                // cleanWs deleteDirs: true, patterns: [[pattern: '.', type: 'INCLUDE'], [pattern: ".venv", type: "EXCLUDE"]]
-            }
+                sh 'chmod -R ugo+rw .'
+                cleanWs deleteDirs: true, patterns: [[pattern: "**/.venv", type: "EXCLUDE"]]
+           }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,7 +168,7 @@ pipeline {
         success {
             script {
                 sh 'find . -user root -name \'*\' | xargs chmod ugo+rw'
-                cleanWs deleteDirs: true, patterns: [[pattern: '.', type: 'INCLUDE'] [pattern: ".venv", type: "EXCLUDE"]]
+                cleanWs deleteDirs: true, patterns: [[pattern: '.', type: 'INCLUDE'], [pattern: ".venv", type: "EXCLUDE"]]
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
         stage('Setup') {
             steps {
                 script {
-                    sh 'find $(pwd) -user root -name * | xargs chmod ugo+rw'
+                    sh 'chmod -R ugo+rw .'
                     cleanWs deleteDirs: true, patterns: [[pattern: "**/.venv", type: "EXCLUDE"]]
 
                     // Clean up any files lying about after the previous build. Jenkins has trouble deleting files given that our containers run as root.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,7 +168,7 @@ pipeline {
         success {
             script {
                 sh 'chmod -R ugo+rw .'
-                cleanWs deleteDirs: true, patterns: [[pattern: "**/.venv/*", type: "EXCLUDE"], [pattern: "**/.venv/**", type: "EXCLUDE"], [pattern: "**/.venv/**/*", type: "EXCLUDE"]]
+                cleanWs patterns: [[pattern: "**/.venv/*", type: "EXCLUDE"], [pattern: "**/.venv/**", type: "EXCLUDE"], [pattern: "**/.venv/**/*", type: "EXCLUDE"]]
            }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,7 +168,7 @@ pipeline {
         success {
             script {
                 sh 'chmod -R ugo+rw .'
-                cleanWs deleteDirs: true, patterns: [[pattern: "**/.venv", type: "EXCLUDE"]]
+                cleanWs deleteDirs: true, patterns: [[pattern: "**/.venv/*", type: "EXCLUDE"]]
            }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
         stage('Setup') {
             steps {
                 script {
-                    // Clean up any files lying about after the previous build. Jenkins has trouble deleting files given that our containers run as root.
+                    // Clean up any unwanted files lying about after the previous build.
                     sh "git clean -fxd --exclude='.venv'"
 
                     dir("devtools") {
@@ -161,8 +161,10 @@ pipeline {
                 }
 
                 archiveArtifacts artifacts: '**/dist/*.whl, **/docs/_build/html/**/*', fingerprint: true
-                
+
+                // Set more permissive permissions on all files so future processes/Jenkins can easily delete them.
                 sh 'chmod -R ugo+rw .'
+                // Clean up any unwanted files lying about.
                 sh "git clean -fxd --exclude='.venv'"
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
                 script {
                     // Clean up any files lying about after the previous build. Jenkins has trouble deleting files given that our containers run as root.
                     // sh "git clean -fxd" 
-                    cleanWs patterns: [[pattern: "**/.venv/*", type: "EXCLUDE"], [pattern: "**/.venv/**", type: "EXCLUDE"], [pattern: "**/.venv/**/*", type: "EXCLUDE"]]
 
                     dir("devtools") {
                         sh "PIPENV_VENV_IN_PROJECT=true pipenv sync --dev"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
                 script {
                     // Clean up any files lying about after the previous build. Jenkins has trouble deleting files given that our containers run as root.
                     // sh "git clean -fxd" 
+                    cleanWs patterns: [[pattern: "**/.venv/*", type: "EXCLUDE"], [pattern: "**/.venv/**", type: "EXCLUDE"], [pattern: "**/.venv/**/*", type: "EXCLUDE"]]
 
                     dir("devtools") {
                         sh "PIPENV_VENV_IN_PROJECT=true pipenv sync --dev"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
             steps {
                 script {
                     // Clean up any files lying about after the previous build. Jenkins has trouble deleting files given that our containers run as root.
-                    // sh "git clean -fxd" 
+                    sh "git clean -fxd --exclude='.venv'"
 
                     dir("devtools") {
                         sh "PIPENV_VENV_IN_PROJECT=true pipenv sync --dev"
@@ -139,8 +139,6 @@ pipeline {
     post {
         always {
             script {
-                sh 'chmod -R ugo+rw .'
-
                 try {
                     unstash name: "test-results"
                 } catch (Exception e) {
@@ -163,13 +161,10 @@ pipeline {
                 }
 
                 archiveArtifacts artifacts: '**/dist/*.whl, **/docs/_build/html/**/*', fingerprint: true
-            }
-        }
-        success {
-            script {
+                
                 sh 'chmod -R ugo+rw .'
-                cleanWs patterns: [[pattern: "**/.venv/*", type: "EXCLUDE"], [pattern: "**/.venv/**", type: "EXCLUDE"], [pattern: "**/.venv/**/*", type: "EXCLUDE"]]
-           }
+                sh "git clean -fxd --exclude='.venv'"
+            }
         }
     }
 }

--- a/csvqb/csvqb/cli/build.py
+++ b/csvqb/csvqb/cli/build.py
@@ -69,5 +69,6 @@ def _override_catalog_metadata_state(
         catalog_metadata_dict: dict = json.load(f)
     overriding_catalog_metadata = CatalogMetadata.from_dict(catalog_metadata_dict)
     cube.metadata.override_with(
-        overriding_catalog_metadata, overriding_keys=catalog_metadata_dict.keys()
+        overriding_catalog_metadata,
+        overriding_keys={k for k in catalog_metadata_dict.keys()},
     )

--- a/csvqb/csvqb/cli/entrypoint.py
+++ b/csvqb/csvqb/cli/entrypoint.py
@@ -29,6 +29,17 @@ def entry_point():
     metavar="CONFIG_PATH",
 )
 @click.option(
+    "--catalog-metadata",
+    "-m",
+    help=(
+        "Location of a JSON file containing the Catalog Metadata for this qube. "
+        "If present, this overrides any configuration found in the info.json."
+    ),
+    type=click.Path(exists=True, path_type=Path, file_okay=True, dir_okay=False),
+    required=False,
+    metavar="CATALOG_METADATA_PATH",
+)
+@click.option(
     "--out",
     "-o",
     help="Location of the CSV-W outputs.",
@@ -56,6 +67,7 @@ def entry_point():
 )
 def build_command(
     config: Path,
+    catalog_metadata: Path,
     out: Path,
     csv: Path,
     fail_when_validation_error: bool,
@@ -65,4 +77,11 @@ def build_command(
     validation_errors_file_out = (
         out / "validation-errors.json" if validation_errors_to_file else None
     )
-    build(config, out, csv, fail_when_validation_error, validation_errors_file_out)
+    build(
+        config,
+        catalog_metadata,
+        out,
+        csv,
+        fail_when_validation_error,
+        validation_errors_file_out,
+    )

--- a/csvqb/csvqb/configloaders/infojson.py
+++ b/csvqb/csvqb/configloaders/infojson.py
@@ -19,6 +19,7 @@ from sharedmodels.rdf.namespaces import GOV, GDP
 
 
 from csvqb.models.cube.cube import Cube
+from csvqb.models.cube.qb import QbCube
 from csvqb.models.cube.qb.catalog import CatalogMetadata
 from csvqb.models.cube.columns import CsvColumn, SuppressedCsvColumn
 from csvqb.models.cube.qb.columns import QbColumn
@@ -49,7 +50,7 @@ import csvqb.configloaders.infojson1point1.mapcolumntocomponent as v1point1
 
 def get_cube_from_info_json(
     info_json: Path, data: pd.DataFrame, cube_id: Optional[str] = None
-) -> Cube:
+) -> QbCube:
     with open(info_json, "r") as f:
         config = json.load(f)
 
@@ -85,7 +86,9 @@ def _override_config_for_cube_id(config: dict, cube_id: str) -> Optional[dict]:
         return None
 
 
-def _from_info_json_dict(d: Dict, data: pd.DataFrame, info_json_parent_dir: Path):
+def _from_info_json_dict(
+    d: Dict, data: pd.DataFrame, info_json_parent_dir: Path
+) -> QbCube:
     metadata = _metadata_from_dict(d)
     transform_section = d.get("transform", {})
     columns = _columns_from_info_json(

--- a/csvqb/csvqb/configloaders/infojson.py
+++ b/csvqb/csvqb/configloaders/infojson.py
@@ -110,7 +110,7 @@ def _metadata_from_dict(config: dict) -> "CatalogMetadata":
         description=config.get("description"),
         creator_uri=publisher,
         publisher_uri=publisher,
-        issued=dt_issued,
+        dataset_issued=dt_issued,
         theme_uris=theme_uris,
         keywords=config.get("keywords", []),
         landing_page_uri=config.get("landingPage"),

--- a/csvqb/csvqb/configloaders/infojson1point1/mapcolumntocomponent.py
+++ b/csvqb/csvqb/configloaders/infojson1point1/mapcolumntocomponent.py
@@ -4,6 +4,7 @@ Mapping
 
 Map info.json V1.1 definitions to QB column components
 """
+import copy
 from typing import Union
 from pathlib import Path
 
@@ -86,31 +87,34 @@ def _from_column_dict_to_schema_model(
     schema.ObservationValue,
 ]:
     """
-    N.B. when using the :method:`dict_has_required_fields` method, we need to ensure that we check for types with
+    N.B. when using the :method:`dict_fields_match_class` method, we need to ensure that we check for types with
     required properties *before* types without required properties.
     """
     column_type = column.get("type")
+    column_without_type = copy.deepcopy(column)
+    del column_without_type["type"]
+
     if column_type is None:
         raise ValueError("Type of column not specified.")
     elif column_type == "dimension":
-        if schema.ExistingDimension.dict_has_required_fields(column):
+        if schema.ExistingDimension.dict_fields_match_class(column_without_type):
             return schema.ExistingDimension.from_dict(column)
-        elif schema.NewDimension.dict_has_required_fields(column):
+        elif schema.NewDimension.dict_fields_match_class(column_without_type):
             return schema.NewDimension.from_dict(column)
     elif column_type == "attribute":
-        if schema.ExistingAttribute.dict_has_required_fields(column):
+        if schema.ExistingAttribute.dict_fields_match_class(column_without_type):
             return schema.ExistingAttribute.from_dict(column)
-        elif schema.NewAttribute.dict_has_required_fields(column):
+        elif schema.NewAttribute.dict_fields_match_class(column_without_type):
             return schema.NewAttribute.from_dict(column)
     elif column_type == "units":
-        if schema.ExistingUnits.dict_has_required_fields(column):
+        if schema.ExistingUnits.dict_fields_match_class(column_without_type):
             return schema.ExistingUnits.from_dict(column)
-        elif schema.NewUnits.dict_has_required_fields(column):
+        elif schema.NewUnits.dict_fields_match_class(column_without_type):
             return schema.NewUnits.from_dict(column)
     elif column_type == "measures":
-        if schema.ExistingMeasures.dict_has_required_fields(column):
+        if schema.ExistingMeasures.dict_fields_match_class(column_without_type):
             return schema.ExistingMeasures.from_dict(column)
-        elif schema.NewMeasures.dict_has_required_fields(column):
+        elif schema.NewMeasures.dict_fields_match_class(column_without_type):
             return schema.NewMeasures.from_dict(column)
     elif column_type == "observations":
         return schema.ObservationValue.from_dict(column)

--- a/csvqb/csvqb/models/cube/catalog.py
+++ b/csvqb/csvqb/models/cube/catalog.py
@@ -19,5 +19,5 @@ class CatalogMetadataBase(PydanticModel, ABC):
         pass
 
     @abstractmethod
-    def get_issued(self) -> datetime:
+    def get_issued(self) -> Optional[datetime]:
         pass

--- a/csvqb/csvqb/models/cube/qb/catalog.py
+++ b/csvqb/csvqb/models/cube/qb/catalog.py
@@ -2,10 +2,12 @@
 Catalog Metadata (DCAT)
 -----------------------
 """
+import json
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
 from sharedmodels.rdf import dcat
+from pathlib import Path
 
 from csvqb.models.cube.catalog import CatalogMetadataBase
 from csvqb.models.uriidentifiable import UriIdentifiable
@@ -35,6 +37,17 @@ class CatalogMetadata(CatalogMetadataBase, UriIdentifiable):
     _public_contact_point_uri_validator = validate_uri(
         "public_contact_point_uri", is_optional=True
     )
+
+    def to_json_file(self, file_path: Path) -> None:
+        with open(file_path, "w+") as f:
+            json.dump(self.as_json_dict(), f, indent=4)
+
+    @classmethod
+    def from_json_file(cls, file_path: Path) -> "CatalogMetadata":
+        with open(file_path, "r") as f:
+            dict_structure = json.load(f)
+
+        return cls.from_dict(dict_structure)
 
     def get_issued(self) -> Optional[datetime]:
         return self.dataset_issued

--- a/csvqb/csvqb/models/cube/qb/catalog.py
+++ b/csvqb/csvqb/models/cube/qb/catalog.py
@@ -9,6 +9,7 @@ from sharedmodels.rdf import dcat
 
 from csvqb.models.cube.catalog import CatalogMetadataBase
 from csvqb.models.uriidentifiable import UriIdentifiable
+from csvqb.utils.validators.uri import validate_uri
 
 
 @dataclass
@@ -21,13 +22,22 @@ class CatalogMetadata(CatalogMetadataBase, UriIdentifiable):
     landing_page_uri: Optional[str] = field(default=None, repr=False)
     theme_uris: list[str] = field(default_factory=list, repr=False)
     keywords: list[str] = field(default_factory=list, repr=False)
-    issued: datetime = field(default_factory=lambda: datetime.now(), repr=False)
+    dataset_issued: Optional[datetime] = field(default=None, repr=False)
+    dataset_modified: Optional[datetime] = field(default=None, repr=False)
     license_uri: Optional[str] = field(default=None, repr=False)
     public_contact_point_uri: Optional[str] = field(default=None, repr=False)
     uri_safe_identifier_override: Optional[str] = field(default=None, repr=False)
 
-    def get_issued(self) -> datetime:
-        return self.issued
+    _creator_uri_validator = validate_uri("creator_uri", is_optional=True)
+    _publisher_uri_validator = validate_uri("publisher_uri", is_optional=True)
+    _landing_page_uri_validator = validate_uri("landing_page_uri", is_optional=True)
+    _license_uri_validator = validate_uri("license_uri", is_optional=True)
+    _public_contact_point_uri_validator = validate_uri(
+        "public_contact_point_uri", is_optional=True
+    )
+
+    def get_issued(self) -> Optional[datetime]:
+        return self.dataset_issued
 
     def get_description(self) -> Optional[str]:
         return self.description
@@ -37,9 +47,11 @@ class CatalogMetadata(CatalogMetadataBase, UriIdentifiable):
 
     def configure_dcat_dataset(self, dataset: dcat.Dataset) -> None:
         dt_now = datetime.now()
+        dt_issued = self.dataset_issued or dt_now
+
         dataset.label = dataset.title = self.title
-        dataset.issued = self.issued or dt_now
-        dataset.modified = dt_now
+        dataset.issued = dt_issued
+        dataset.modified = self.dataset_modified or dt_issued
         dataset.comment = self.summary
         dataset.description = self.description
         dataset.license = self.license_uri

--- a/csvqb/csvqb/models/pydanticmodel.py
+++ b/csvqb/csvqb/models/pydanticmodel.py
@@ -1,11 +1,12 @@
 import dataclasses
-from dataclasses import dataclass, asdict, fields, is_dataclass
+from dataclasses import dataclass, fields, is_dataclass
 import pydantic
 import pydantic.dataclasses
 from pydantic import BaseConfig
 from typing import Dict, Type, List, Iterable, Union, Any
 from abc import ABC
 
+from sharedmodels.dataclassbase import DataClassBase
 
 from .validationerror import ValidationError
 
@@ -14,7 +15,7 @@ _map_class_to_pydantic_constructor: Dict[Type, Type] = dict()
 
 
 @dataclass
-class PydanticModel(ABC):
+class PydanticModel(DataClassBase, ABC):
     """
     ValidatedModel - an abstract base class to be inherited by models which want a `validate` method which verifies
     that the model's attributes agree with the corresponding type annotations.
@@ -38,14 +39,6 @@ class PydanticModel(ABC):
                 config=getattr(PydanticModel, "Config", PydanticModel._DefaultConfig),
             )
         return _map_class_to_pydantic_constructor[cls]
-
-    def as_dict(self) -> dict:
-        """Use python dataclasses method to return this model as a dictionary."""
-        return asdict(self)
-
-    def _as_shallow_dict(self) -> dict:
-        """Returns a dictionary which is essentially a shallow copy of this dataclass."""
-        return dict([(f.name, getattr(self, f.name)) for f in fields(self)])
 
     def _to_pydantic_dataclass_or_validation_errors(
         self,

--- a/csvqb/csvqb/tests/behaviour/cli.feature
+++ b/csvqb/csvqb/tests/behaviour/cli.feature
@@ -39,3 +39,14 @@ Feature: Test the csvqb Command Line Interface.
     Then the csvqb CLI should succeed
     And the file at "out/validation-error-output.csv" should exist
     And the file at "out/validation-error-output.csv-metadata.json" should exist
+
+
+  Scenario: The csvqb build command should accept an optional catalog-metadata.json which overrides the info.json configuration
+    Given the existing test-case file "configloaders/data.csv"
+    And the existing test-case file "configloaders/info.json"
+    And the existing test-case file "configloaders/catalog-metadata.json"
+    When the csvqb CLI is run with "build --config configloaders/info.json --catalog-metadata configloaders/catalog-metadata.json configloaders/data.csv"
+    Then the csvqb CLI should succeed
+    And the file at "out/some-dataset.csv" should exist
+    And the file at "out/some-dataset.csv-metadata.json" should exist
+    But the file at "out/ons-international-trade-in-services-by-subnational-areas-of-the-uk.csv" should not exist

--- a/csvqb/csvqb/tests/behaviour/steps/cli.py
+++ b/csvqb/csvqb/tests/behaviour/steps/cli.py
@@ -14,7 +14,7 @@ def step_impl(context, arguments: str):
 @then("the csvqb CLI should succeed")
 def step_impl(context):
     (status_code, response) = context.csvqb_cli_result
-    assert status_code == 0, status_code
+    assert status_code == 0, (status_code, response)
     assert "Build Complete" in response, response
 
 

--- a/csvqb/csvqb/tests/test-cases/configloaders/catalog-metadata.json
+++ b/csvqb/csvqb/tests/test-cases/configloaders/catalog-metadata.json
@@ -1,0 +1,19 @@
+{
+    "title": "Some Dataset",
+    "uri_safe_identifier_override": "some-dataset",
+    "summary": "Some catalog item summary",
+    "description": "Some catalog item description",
+    "creator_uri": "http://some-creator-uri",
+    "publisher_uri": "http://some-publisher-uri",
+    "landing_page_uri": "http://some-landing-page-uri",
+    "theme_uris": [
+        "http://some-theme-uri"
+    ],
+    "keywords": [
+        "Some key word"
+    ],
+    "dataset_issued": "2010-01-01T01:01:01.000001",
+    "dataset_modified": "2010-01-01T02:01:01.000001",
+    "license_uri": "http://some-license-uri",
+    "public_contact_point_uri": "mailto:somecontactpoint@ons.gov.uk"
+}

--- a/csvqb/csvqb/tests/unit/configloaders/test_infojsontests.py
+++ b/csvqb/csvqb/tests/unit/configloaders/test_infojsontests.py
@@ -156,7 +156,7 @@ def test_cube_metadata_extracted_from_info_json():
     # issue_date - pass
 
     expected_issued_date = parser.parse("2019-02-28")
-    actual_issued_date = cube.metadata.issued
+    actual_issued_date = cube.metadata.dataset_issued
     assert actual_issued_date == expected_issued_date
 
     # keywords - pass

--- a/csvqb/csvqb/tests/unit/cube/qb/test_catalog_metadata.py
+++ b/csvqb/csvqb/tests/unit/cube/qb/test_catalog_metadata.py
@@ -1,0 +1,69 @@
+import datetime
+
+import pytest
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+from csvqb.models.cube.qb.catalog import CatalogMetadata
+
+
+def test_serialise_and_load_json():
+    """
+    Ensure that we can correctly serialise and de-serialise all CatalogMetadata fields to JSON.
+    """
+    with TemporaryDirectory() as tmp_dir_path:
+        catalog_metadata = CatalogMetadata(
+            title="Some catalog item",
+            identifier="some-catalog-thingy",
+            uri_safe_identifier_override="some-uri-safe-override",
+            description="Some catalog item description",
+            summary="Some catalog item summary",
+            dataset_issued=datetime.datetime(2010, 1, 1, 1, 1, 1, 1),
+            dataset_modified=datetime.datetime(2010, 1, 1, 2, 1, 1, 1),
+            theme_uris=["http://some-theme-uri"],
+            license_uri="http://some-license-uri",
+            keywords=["Some key word"],
+            creator_uri="http://some-creator-uri",
+            publisher_uri="http://some-publisher-uri",
+            public_contact_point_uri="mailto:somecontactpoint@ons.gov.uk",
+            landing_page_uri="http://some-landing-page-uri",
+        )
+
+        tmp_dir_path = Path(tmp_dir_path)
+        json_file = tmp_dir_path / "catalog-metadata.json"
+        catalog_metadata.to_json_file(json_file)
+        reinflated_catalog_metadata = catalog_metadata.from_json_file(json_file)
+
+        assert reinflated_catalog_metadata.title == "Some catalog item"
+        assert reinflated_catalog_metadata.identifier == "some-catalog-thingy"
+        assert (
+            reinflated_catalog_metadata.uri_safe_identifier_override
+            == "some-uri-safe-override"
+        )
+        assert (
+            reinflated_catalog_metadata.description == "Some catalog item description"
+        )
+        assert reinflated_catalog_metadata.summary == "Some catalog item summary"
+        assert reinflated_catalog_metadata.dataset_issued == datetime.datetime(
+            2010, 1, 1, 1, 1, 1, 1
+        )
+        assert reinflated_catalog_metadata.dataset_modified == datetime.datetime(
+            2010, 1, 1, 2, 1, 1, 1
+        )
+        assert reinflated_catalog_metadata.theme_uris == ["http://some-theme-uri"]
+        assert reinflated_catalog_metadata.license_uri == "http://some-license-uri"
+        assert reinflated_catalog_metadata.keywords == ["Some key word"]
+        assert reinflated_catalog_metadata.creator_uri == "http://some-creator-uri"
+        assert reinflated_catalog_metadata.publisher_uri == "http://some-publisher-uri"
+        assert (
+            reinflated_catalog_metadata.public_contact_point_uri
+            == "mailto:somecontactpoint@ons.gov.uk"
+        )
+        assert (
+            reinflated_catalog_metadata.landing_page_uri
+            == "http://some-landing-page-uri"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/sharedmodels/sharedmodels/dataclassbase.py
+++ b/sharedmodels/sharedmodels/dataclassbase.py
@@ -296,7 +296,7 @@ def replace_with_json_serialisable_types(val: Any) -> Any:
     """
     :return: A replacement of built-in types which are not JSON serialisable with ones which are.
 
-    e.g. :obj:`~datetime.datetime`s get replaced with ISO-8601 strings.
+    e.g. :obj:`~datetime.datetime` instances get replaced with ISO-8601 strings.
 
     Its inverse is :func:`replace_serialised_types_with_builtin_types`.
     """

--- a/sharedmodels/sharedmodels/dataclassbase.py
+++ b/sharedmodels/sharedmodels/dataclassbase.py
@@ -45,11 +45,13 @@ class DataClassBase(ABC):
         """Use python dataclasses method to return this model as a dictionary."""
         return asdict(self)
 
-    def as_json_dict(self) -> str:
+    def as_json_dict(self) -> dict:
         """
         :return: a dict suitable for JSON serialisation containing a representation of this object.
         """
-        return replace_with_json_serialisable_types(self.as_dict())
+        d = replace_with_json_serialisable_types(self.as_dict())
+        assert isinstance(d, dict)
+        return d
 
     def as_json(self) -> str:
         """
@@ -290,10 +292,7 @@ class DataClassBase(ABC):
         return type_hints
 
 
-T = typing.TypeVar("T")
-
-
-def replace_with_json_serialisable_types(val: T) -> typing.Union[T, str]:
+def replace_with_json_serialisable_types(val: Any) -> Any:
     """
     :return: A replacement of built-in types which are not JSON serialisable with ones which are.
 

--- a/sharedmodels/sharedmodels/dataclassbase.py
+++ b/sharedmodels/sharedmodels/dataclassbase.py
@@ -1,0 +1,232 @@
+"""
+DataClass Base
+--------------
+
+Provides some utilities to help with serialisation/deserialisation
+"""
+import collections
+import copy
+import typing
+from abc import ABC
+from dataclasses import Field, _MISSING_TYPE, fields, asdict, dataclass
+from typing import List, Any, get_type_hints, Dict, Set, Type
+
+
+class DataClassFromDictValueError(ValueError):
+    ...
+
+
+_map_coercion_permitted: Dict[Type, Set[Type]] = {int: {float}}
+"""Map of coercion directions permitted, value type => expected static type"""
+
+
+def _type_coercion_permitted(value_data_type: Type, annotation_data_type: Type) -> bool:
+    permitted_coercions = _map_coercion_permitted.get(value_data_type)
+    return (
+        permitted_coercions is not None and annotation_data_type in permitted_coercions
+    )
+
+
+TDataClassBase = typing.TypeVar("TDataClassBase", bound="DataClassBase")
+
+
+@dataclass
+class DataClassBase(ABC):
+    def as_dict(self) -> dict:
+        """Use python dataclasses method to return this model as a dictionary."""
+        return asdict(self)
+
+    def _as_shallow_dict(self) -> dict:
+        """Returns a dictionary which is essentially a shallow copy of this dataclass."""
+        return dict([(f.name, getattr(self, f.name)) for f in fields(self)])
+
+    @classmethod
+    def dict_fields_match_class(cls: typing.Type, d: dict) -> bool:
+        fields_in_class = fields(cls)
+        field_defined_keys = {field.name for field in fields_in_class}
+
+        required_fields: List[Field] = [
+            f
+            for f in fields_in_class
+            if isinstance(f.default, _MISSING_TYPE)
+            and isinstance(f.default_factory, _MISSING_TYPE)
+        ]
+        all_required_fields_present = all([f.name in d.keys() for f in required_fields])
+        dict_keys_undefined_in_class = any(
+            [k for k in d.keys() if k not in field_defined_keys]
+        )
+
+        return all_required_fields_present and not dict_keys_undefined_in_class
+
+    @classmethod
+    def _get_type_hints(cls) -> dict:
+        """
+        Fetches type hints associated with this class.
+
+        Ensures that overridden properties have their type hints overridden too.
+        """
+        type_hints = {}
+        for c in reversed(cls.mro()):
+            type_hints = dict(type_hints, **get_type_hints(c, include_extras=True))
+
+        return type_hints
+
+    @classmethod
+    def from_dict(cls: Type[TDataClassBase], d: dict) -> TDataClassBase:
+        """
+        Attempt to inflate an instance of this class from a dictionary of values using static type annotations as
+        guides.
+
+        N.B. this won't work in all cases. You should *really* test this against all of the classes you're expecting
+        to be able to inflate.
+        """
+
+        all_fields: List[Field] = list(fields(cls))
+        init_fields = [f for f in all_fields if f.init]
+        non_init_fields = [f for f in all_fields if not f.init]
+
+        type_hints = cls._get_type_hints()
+        init_values = {}
+        for field in init_fields:
+            init_values[field.name] = cls._get_value_for_field(d, field, type_hints)
+
+        instance = cls(**init_values)  # type: ignore
+
+        for field in non_init_fields:
+            field_value = cls._get_value_for_field(d, field, type_hints)
+            setattr(instance, field.name, field_value)
+
+        return instance
+
+    @classmethod
+    def _get_value_for_field(
+        cls, dict_values: dict, field: Field, type_hints: Dict[str, Any]
+    ) -> Any:
+        if field.name in dict_values.keys():
+            val = dict_values[field.name]
+            typing_hint = type_hints.get(field.name)
+            if typing_hint is not None:
+                val = cls._get_value_for_typed_field(val, field, typing_hint)
+
+            return val
+        elif not isinstance(field.default, _MISSING_TYPE):
+            return copy.deepcopy(field.default)
+        elif not isinstance(field.default_factory, _MISSING_TYPE):
+            return field.default_factory()
+        else:
+            raise DataClassFromDictValueError(
+                f"Missing required field '{field.name}' on {cls}. Values provided: {dict_values}."
+            )
+
+    @classmethod
+    def _get_value_for_typed_field(
+        cls, val: Any, field: Field, typing_hint: Any, allow_coercion: bool = True
+    ) -> Any:
+        generic_type_args = typing.get_args(typing_hint)
+        value_type = type(val)
+
+        if value_type == typing_hint:
+            return val
+        elif (
+            isinstance(val, dict)
+            and isinstance(typing_hint, type)
+            and issubclass(typing_hint, DataClassBase)
+            and typing_hint.dict_fields_match_class(val)
+        ):
+            # recursive application of `from_dict`.
+            return typing_hint.from_dict(val)
+        elif len(generic_type_args) > 0:
+            origin_type = typing.get_origin(typing_hint)
+            if isinstance(origin_type, type) and issubclass(
+                origin_type, collections.Iterable
+            ):
+                return cls._get_value_for_generic_iterable_field(
+                    field, typing_hint, origin_type, generic_type_args, val
+                )
+            elif origin_type == typing.Union:
+                return cls._get_value_for_generic_union(
+                    field, typing_hint, generic_type_args, val
+                )
+            else:
+                raise DataClassFromDictValueError(
+                    f"Unable to inflate generic type {typing_hint} from dictionary."
+                )
+        elif allow_coercion and _type_coercion_permitted(value_type, typing_hint):
+            try:
+                return typing_hint(val)  # type: ignore
+            except:
+                ...
+
+        raise DataClassFromDictValueError(
+            f"Could not match {val} with static type {typing_hint}"
+        )
+
+    @classmethod
+    def _get_value_for_generic_iterable_field(
+        cls,
+        field: Field,
+        typing_hint: Any,
+        origin_type: Any,
+        generic_type_args: collections.Iterable,
+        val: Any,
+    ) -> Any:
+        generic_type_args = list(generic_type_args)
+
+        if not isinstance(val, collections.Iterable):
+            raise DataClassFromDictValueError(
+                f"Unable to inflate {cls.__name__}.{field.name} as dictionary value is not list: {val}"
+            )
+
+        typing_args_contain_subclass_dataclassbase = (
+            cls._get_generic_type_arg_subclassing_dataclassbase(generic_type_args)
+        )
+
+        if len(typing_args_contain_subclass_dataclassbase) > 0:
+            if len(generic_type_args) == 1:
+                iterable_value_type = generic_type_args[0]
+                mapped_child_values = [
+                    cls._get_value_for_typed_field(v, field, iterable_value_type)
+                    for v in val
+                ]
+                return origin_type(mapped_child_values)
+            elif len(generic_type_args) > 1:
+                raise DataClassFromDictValueError(
+                    f"Unable to inflate generic type {typing_hint} from dictionary."
+                )
+        return val
+
+    @classmethod
+    def _get_generic_type_arg_subclassing_dataclassbase(
+        cls, generic_type_args: collections.Iterable
+    ) -> Set:
+        args_subclassing_dataclassbase = {
+            a
+            for a in generic_type_args
+            if isinstance(a, type) and issubclass(a, DataClassBase)
+        }
+
+        for a in generic_type_args:
+            args = typing.get_args(a)
+            # recursive search down the type tree to see if we can find anything subclassing DataClassBase.
+            if len(cls._get_generic_type_arg_subclassing_dataclassbase(args)) > 0:
+                args_subclassing_dataclassbase.add(a)
+
+        return args_subclassing_dataclassbase
+
+    @classmethod
+    def _get_value_for_generic_union(
+        cls,
+        field: Field,
+        union_typing_hint: Any,
+        generic_type_args: collections.Iterable,
+        val: Any,
+    ) -> Any:
+        for arg in generic_type_args:
+            try:
+                return cls._get_value_for_typed_field(val, field, arg)
+            except DataClassFromDictValueError:
+                pass
+
+        raise DataClassFromDictValueError(
+            f"Could not find matching type in union {union_typing_hint} to represent {val}"
+        )

--- a/sharedmodels/sharedmodels/tests/unit/test_dataclassbase.py
+++ b/sharedmodels/sharedmodels/tests/unit/test_dataclassbase.py
@@ -1,0 +1,330 @@
+from dataclasses import dataclass, field
+from typing import List, Set, Dict, TypeVar, Generic, Union
+
+import pytest
+
+from sharedmodels.dataclassbase import DataClassBase
+
+
+def test_write_to_deep_dict():
+    """
+    Test conversion of a dataclass structure to dict
+    """
+
+    @dataclass
+    class A(DataClassBase):
+        a_1: str
+
+    @dataclass
+    class B(DataClassBase):
+        b_1: str
+        b_2: A
+        b_3: dict
+
+    a = A("Hello from a")
+    b = B("Hello from b", a, {"key": "value"})
+
+    b_dict = b.as_dict()
+
+    assert b_dict == {
+        "b_1": "Hello from b",
+        "b_2": {"a_1": "Hello from a"},
+        "b_3": {"key": "value"},
+    }
+
+
+def test_inflate_non_init_fields():
+    @dataclass
+    class A(DataClassBase):
+        a_1: str
+        a_2: str = field(init=False)
+
+        def __post_init__(self):
+            self.a_2 = self.a_1.capitalize()
+
+    a = A.from_dict({"a_1": "Hello from a", "a_2": "Something different"})
+
+    assert isinstance(a, A)
+    assert a.a_1 == "Hello from a"
+    assert a.a_2 == "Something different"
+
+
+def test_inflate_from_deep_dict():
+    """
+    Test conversion of a deep dictionary to the expected dataclass structure
+    """
+
+    @dataclass
+    class A(DataClassBase):
+        a_1: str
+
+    @dataclass
+    class B(DataClassBase):
+        b_1: str
+        b_2: A
+        b_3: dict
+
+    b = B.from_dict(
+        {"b_1": "Hello from B", "b_2": {"a_1": "Hello from A"}, "b_3": {"key": "value"}}
+    )
+
+    assert isinstance(b, B)
+    assert b.b_1 == "Hello from B"
+    assert isinstance(b.b_2, A)
+    assert b.b_2.a_1 == "Hello from A"
+    assert isinstance(b.b_3, dict)
+    assert b.b_3 == {"key": "value"}
+
+
+def test_inflate_from_list():
+    """
+    Test conversion of a deep dictionary to the expected dataclass structure
+    """
+
+    @dataclass
+    class A(DataClassBase):
+        a_1: str
+        a_2: List[str]
+
+    a = A.from_dict({"a_1": "Hello from A", "a_2": ["Val 1", "Val 2"]})
+
+    assert isinstance(a, A)
+    assert a.a_1 == "Hello from A"
+    assert isinstance(a.a_2, list)
+    assert a.a_2 == ["Val 1", "Val 2"]
+
+
+def test_inflate_from_list_deep():
+    """
+    Test conversion of a deep dictionary inside a generic list to the expected dataclass structure
+    """
+
+    @dataclass
+    class A(DataClassBase):
+        a_1: str
+
+    @dataclass
+    class B(DataClassBase):
+        b_1: str
+        b_2: List[A]
+
+    b = B.from_dict(
+        {
+            "b_1": "Hello from B",
+            "b_2": [
+                {"a_1": "Hello from the first A"},
+                {"a_1": "Hello from the second A"},
+            ],
+        }
+    )
+
+    assert isinstance(b, B)
+    assert b.b_1 == "Hello from B"
+    assert isinstance(b.b_2, list)
+    assert b.b_2 == [A("Hello from the first A"), A("Hello from the second A")]
+
+
+def test_inflate_from_set_deep():
+    """
+    Test conversion of a deep dictionary/set structure to the expected dataclass structure
+    """
+
+    @dataclass(unsafe_hash=True)
+    class A(DataClassBase):
+        a_1: str
+
+    @dataclass
+    class B(DataClassBase):
+        b_1: str
+        b_2: Set[A]
+
+    b = B.from_dict(
+        {
+            "b_1": "Hello from B",
+            "b_2": [  # Has to be a list since dictionaries are un-hashable (so cannot be in a set).
+                {"a_1": "Hello from the first A"},
+                {"a_1": "Hello from the second A"},
+            ],
+        }
+    )
+
+    assert isinstance(b, B)
+    assert b.b_1 == "Hello from B"
+    assert isinstance(b.b_2, set)
+    assert b.b_2 == {A("Hello from the first A"), A("Hello from the second A")}
+
+
+def test_inflate_from_deep_generic_type_failure():
+    """
+    Demonstrate that deserialising more generic types which are have subclasses of DataClassBase as type
+     arguments should not succeed.
+    """
+    T = TypeVar("T")
+
+    @dataclass(unsafe_hash=True)
+    class A(DataClassBase, Generic[T]):
+        a_1: str
+
+    @dataclass
+    class B(DataClassBase, Generic[T]):
+        b_1: A[T]
+
+    with pytest.raises(ValueError) as err:
+        B[str].from_dict(
+            {
+                "b_1": {"a_1": "Hello, world"},
+            }
+        )
+
+    assert "Unable to inflate" in str(err)
+
+
+def test_inflate_from_dict_deep_failure():
+    """
+    Demonstrate that deserialising more complex generic types like Dict[str, A] is not currently supported.
+    """
+
+    T = TypeVar("T")
+
+    @dataclass
+    class A(DataClassBase, Generic[T]):
+        a_1: T
+
+    @dataclass
+    class B(DataClassBase, Generic[T]):
+        b_2: Dict[str, A]
+
+    with pytest.raises(ValueError) as err:
+        B.from_dict(
+            {
+                "b_1": "Hello from B",
+                "b_2": {
+                    "First": {"a_1": "Hello from the first A"},
+                    "Second": {"a_1": "Hello from the second A"},
+                },
+            }
+        )
+
+    assert "Unable to inflate" in str(err)
+
+
+def test_inflate_from_union_deep():
+    """
+    Test conversion of a deep Union structure to the expected dataclass structure
+    """
+
+    @dataclass(unsafe_hash=True)
+    class A(DataClassBase):
+        a_1: str
+
+    @dataclass
+    class B(DataClassBase):
+        b_1: str
+        b_2: Union[A, str, List[A]]
+
+    b = B.from_dict(
+        {
+            "b_1": "Hello from B",
+            "b_2": "Hello again from B",
+        }
+    )
+
+    assert isinstance(b, B)
+    assert b.b_1 == "Hello from B"
+    assert isinstance(b.b_2, str)
+    assert b.b_2 == "Hello again from B"
+
+    b = B.from_dict(
+        {
+            "b_1": "Hello from B",
+            "b_2": {"a_1": "Hello from A"},
+        }
+    )
+
+    assert isinstance(b, B)
+    assert b.b_1 == "Hello from B"
+    assert isinstance(b.b_2, A)
+    assert b.b_2.a_1 == "Hello from A"
+
+    b = B.from_dict(
+        {
+            "b_1": "Hello from B",
+            "b_2": [
+                {"a_1": "Hello from the first A"},
+                {"a_1": "Hello from the second A"},
+            ],
+        }
+    )
+
+    assert isinstance(b, B)
+    assert b.b_1 == "Hello from B"
+    assert isinstance(b.b_2, list)
+    assert b.b_2 == [A("Hello from the first A"), A("Hello from the second A")]
+
+
+def test_inflate_from_list_of_lists_deep():
+    """
+    Test conversion of a deep list of lists structure to the expected dataclass structure
+    """
+
+    @dataclass(unsafe_hash=True)
+    class A(DataClassBase):
+        a_1: str
+
+    @dataclass
+    class B(DataClassBase):
+        b_1: str
+        b_2: List[List[A]]
+
+    b = B.from_dict(
+        {
+            "b_1": "Hello from B",
+            "b_2": [[{"a_1": "Hello from A"}]],
+        }
+    )
+
+    assert isinstance(b, B)
+    assert b.b_1 == "Hello from B"
+    assert isinstance(b.b_2, list)
+    assert len(b.b_2) == 1
+    first_item = b.b_2[0]
+    assert isinstance(first_item, list)
+    first_item = first_item[0]
+    assert isinstance(first_item, A)
+    assert first_item.a_1 == "Hello from A"
+
+
+def test_inflate_from_list_of_sets_deep():
+    """
+    Test conversion of a deep list of sets structure to the expected dataclass structure
+    """
+
+    @dataclass(unsafe_hash=True)
+    class A(DataClassBase):
+        a_1: str
+
+    @dataclass
+    class B(DataClassBase):
+        b_1: str
+        b_2: List[Set[A]]
+
+    b = B.from_dict(
+        {
+            "b_1": "Hello from B",
+            "b_2": [[{"a_1": "Hello from A"}]],
+        }
+    )
+
+    assert isinstance(b, B)
+    assert b.b_1 == "Hello from B"
+    assert isinstance(b.b_2, list)
+    assert len(b.b_2) == 1
+    first_item = b.b_2[0]
+    assert isinstance(first_item, set)
+    first_item = first_item.pop()
+    assert isinstance(first_item, A)
+    assert first_item.a_1 == "Hello from A"
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/sharedmodels/sharedmodels/tests/unit/test_dataclassbase.py
+++ b/sharedmodels/sharedmodels/tests/unit/test_dataclassbase.py
@@ -1,3 +1,4 @@
+import datetime
 from dataclasses import dataclass, field
 from typing import List, Set, Dict, TypeVar, Generic, Union
 
@@ -324,6 +325,19 @@ def test_inflate_from_list_of_sets_deep():
     first_item = first_item.pop()
     assert isinstance(first_item, A)
     assert first_item.a_1 == "Hello from A"
+
+
+def test_datetime_json_serialisation():
+    @dataclass
+    class A(DataClassBase):
+        some_datetime: datetime.datetime
+
+    dt = datetime.datetime.now()
+
+    a = A(dt)
+    reinflated_a = a.from_json(a.as_json())
+    assert isinstance(reinflated_a, A)
+    assert reinflated_a.some_datetime == dt
 
 
 if __name__ == "__main__":

--- a/sharedmodels/sharedmodels/tests/unit/test_dataclassbase.py
+++ b/sharedmodels/sharedmodels/tests/unit/test_dataclassbase.py
@@ -1,6 +1,6 @@
 import datetime
 from dataclasses import dataclass, field
-from typing import List, Set, Dict, TypeVar, Generic, Union
+from typing import List, Set, Dict, TypeVar, Generic, Union, Optional
 
 import pytest
 
@@ -338,6 +338,49 @@ def test_datetime_json_serialisation():
     reinflated_a = a.from_json(a.as_json())
     assert isinstance(reinflated_a, A)
     assert reinflated_a.some_datetime == dt
+
+
+def test_override_values():
+    @dataclass
+    class A(DataClassBase):
+        some_optional_value: Optional[str] = None
+
+    a = A("Hello, World")
+    a_override = A()
+
+    a.override_with(a_override)
+
+    assert a.some_optional_value is None
+
+
+def test_overriding_nothing():
+    @dataclass
+    class A(DataClassBase):
+        some_optional_value: Optional[str] = None
+
+    a = A("Hello, World")
+    a_override = A()
+
+    a.override_with(a_override, overriding_keys=set())
+
+    assert a.some_optional_value == "Hello, World"
+
+
+def test_overriding_specific_property():
+    @dataclass
+    class A(DataClassBase):
+        some_value: str
+        some_optional_value: Optional[str] = None
+
+    a = A("Hello, world", "This is optional")
+    a_override = A("Hello, overriding world.")
+
+    a.override_with(a_override, overriding_keys={"some_value"})
+
+    assert a.some_value == "Hello, overriding world."
+
+    # But some_optional_value doesn't get overridden since it isn't in `overriding_keys`.
+    assert a.some_optional_value == "This is optional"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Added functionality to read/write dataclasses to/from JSON.
- Added functinoality to override specific properties on said dataclasses (useful for overriding CatalogMetadata with the scraper's metadata).
- Added param to csvqb CLI to accept additonal catalog metadata JSON to override defaults from info.json file.

Part of Issue #28.